### PR TITLE
Process concepts phase (P-PC.1–P-PC.7)

### DIFF
--- a/adapter/harness/__init__.py
+++ b/adapter/harness/__init__.py
@@ -129,7 +129,7 @@ from .hypothesis import (
     generate_hypotheses,
     symptom_inference,
 )
-from .loop import run_one_iteration, select_best_action
+from .loop import initialize_harness, run_one_iteration, select_best_action
 from .memory import (
     CompressionRisk,
     MemoryState,
@@ -201,6 +201,13 @@ from .risk import (
     compute_file_centrality,
     estimate_risk,
 )
+from .process_concept import (
+    ProcessConcept,
+    ProcessConceptNotFoundError,
+    ProcessConceptStep,
+    ProcessConceptValidationError,
+)
+from .process_registry import DEFAULT_REGISTRY, ProcessRegistry
 from .staleness import assert_generation_fresh, increment_generation_id, staleness_check, staleness_sweep
 from .state_store import HarnessRunState
 from .task_graph import (
@@ -286,6 +293,7 @@ __all__ = [
     "compile_world_model_node",
     # Phase 8
     "DEFAULT_STRATEGY_ORDER",
+    "DEFAULT_REGISTRY",
     "STRATEGY_ORDER",
     "TOOL_RELIABILITY_ENVELOPES",
     # Phase 5
@@ -328,6 +336,7 @@ __all__ = [
     "FailurePattern",
     "FrozenManifestError",
     "HarnessRunState",
+    "initialize_harness",
     "Hypothesis",
     "HypothesisSet",
     "LayerResult",
@@ -338,6 +347,11 @@ __all__ = [
     "Observation",
     "OutputContract",
     "PendingUpdate",
+    "ProcessConcept",
+    "ProcessConceptNotFoundError",
+    "ProcessConceptStep",
+    "ProcessConceptValidationError",
+    "ProcessRegistry",
     "PostgresNotifyChannel",
     "ReliabilityClass",
     "ReplanScope",

--- a/adapter/harness/loop.py
+++ b/adapter/harness/loop.py
@@ -31,12 +31,70 @@ from .control_state import ControlState, resolve_control_state
 from .diagnostics import Diagnostics
 from .escalation import EscalationReason
 from .external_updates import NoOpUpdateChannel, UpdateChannel, check_external_updates
-from .gates import action_gate, post_exec_gate
+from .gates import action_gate, decomposition_gate, post_exec_gate
 from .memory import MemoryState, apply_retention_policy, check_max_steps, compress_memory, should_compress
 from .progress import cannot_make_progress
 from .recovery import StrategyState, switch_strategy
 from .replanning import ReplanScope, apply_replan, assess_replan_scope
 from .staleness import increment_generation_id
+
+
+def initialize_harness(
+    world_model: Any,
+    diagnostics: Diagnostics,
+    task_graph: Any,
+    process_concept: Any | None = None,
+    experience_store: Any | None = None,
+    strategy_state: StrategyState | None = None,
+    failure_diagnostics: Any | None = None,
+    task_class: str = "",
+    dep_graph_budget: Any | None = None,
+) -> dict[str, Any]:
+    """Initialise the harness for a new run — P-PC.4.
+
+    If process_concept is provided its steps are seeded into task_graph before
+    validate_task_graph() runs. The model-driven decomposition_gate() is never
+    bypassed (INV-PC-01). When experience_store is provided warm_start() is
+    called after concept seeding so the two signals are additive (INV-PC-05).
+
+    Returns a dict with keys:
+      valid (bool), errors (list[str]), decomposition_gate (bool),
+      process_concept_id (str | None).
+    """
+    from .task_graph import validate_task_graph
+
+    if process_concept is not None:
+        process_concept.seed_task_graph(task_graph)
+
+    errors = validate_task_graph(task_graph)
+    if errors:
+        return {
+            "valid": False,
+            "errors": errors,
+            "decomposition_gate": False,
+            "process_concept_id": getattr(process_concept, "id", None),
+        }
+
+    if experience_store is not None:
+        from .experience_store import warm_start
+
+        warm_start(
+            experience_store=experience_store,
+            strategy_state=strategy_state,
+            failure_diagnostics=failure_diagnostics,
+            task_graph=task_graph,
+            task_class=task_class or None,
+            dep_graph_budget=dep_graph_budget,
+        )
+
+    gate_result = decomposition_gate(world_model, diagnostics, task_graph)
+
+    return {
+        "valid": True,
+        "errors": [],
+        "decomposition_gate": gate_result,
+        "process_concept_id": getattr(process_concept, "id", None),
+    }
 
 
 def select_best_action(

--- a/adapter/harness/node_compilers.py
+++ b/adapter/harness/node_compilers.py
@@ -367,6 +367,24 @@ def compile_reviewer_pass_node(
     )
 
 
+
+def compile_process_concept_node(node: dict, harness_meta_var: str) -> str:
+    """Generate Python code for a process_concept canvas node.
+
+    Emits the concept_id into harness_meta.process_concept_id so that the run
+    handler can load and seed the task graph before the first iteration fires.
+    """
+    config = node.get("harness_config") or {}
+    concept_id: str = config.get("concept_id", "")
+
+    return (
+        f"if hasattr({harness_meta_var}, 'process_concept_id'):\n"
+        f"    {harness_meta_var}.process_concept_id = {concept_id!r}\n"
+        f"elif isinstance({harness_meta_var}, dict):\n"
+        f"    {harness_meta_var}['process_concept_id'] = {concept_id!r}\n"
+    )
+
+
 # Dispatch table — shared across all framework adapters.
 # Framework-specific wiring is deferred to P11; this ensures the node types
 # are not silently skipped during compilation.
@@ -385,4 +403,6 @@ HARNESS_NODE_COMPILERS: dict[str, object] = {
     "evidence_store_node": compile_evidence_store_node,
     "experience_store_node": compile_experience_store_node,
     "reviewer_pass": compile_reviewer_pass_node,
+    # Process concepts
+    "process_concept": compile_process_concept_node,
 }

--- a/adapter/harness/process_concept.py
+++ b/adapter/harness/process_concept.py
@@ -1,0 +1,264 @@
+"""
+Process concept data model and task-graph seeding — P-PC.1, P-PC.2.
+
+A ProcessConcept is a human-authored canonical decomposition for a task class.
+It seeds the TaskGraph at harness initialisation and is a strong prior, not
+a constraint (INV-PC-01). The model-driven replanning path remains intact.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Module-level mtime cache: path (str) → (mtime: float, concept: ProcessConcept)
+_FILE_CACHE: dict[str, tuple[float, "ProcessConcept"]] = {}
+
+
+# ── Errors ────────────────────────────────────────────────────────────────────
+
+
+class ProcessConceptValidationError(ValueError):
+    """Raised when a concept file fails structural validation."""
+
+
+class ProcessConceptNotFoundError(KeyError):
+    """Raised when a requested concept ID is not registered."""
+
+
+# ── Abstraction level mapping ─────────────────────────────────────────────────
+
+_ABSTRACTION_MAP: dict[str, int] = {
+    "module": 0,
+    "goal": 0,
+    "subgoal": 1,
+    "function": 1,
+    "leaf": 2,
+    "statement": 2,
+}
+
+_VALID_RISK_LEVELS = {"LOW", "MEDIUM", "HIGH"}
+_VALID_ABSTRACTION_LEVELS = set(_ABSTRACTION_MAP.keys())
+
+
+# ── Data model ────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ProcessConceptStep:
+    id: str
+    description: str
+    depends_on: list[str] = field(default_factory=list)
+    risk_level: str = "LOW"
+    abstraction_level: str = "module"
+    expected_tools: list[str] = field(default_factory=list)
+    success_criteria: list[str] = field(default_factory=list)
+    strategy_hint: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "description": self.description,
+            "depends_on": list(self.depends_on),
+            "risk_level": self.risk_level,
+            "abstraction_level": self.abstraction_level,
+            "expected_tools": list(self.expected_tools),
+            "success_criteria": list(self.success_criteria),
+            "strategy_hint": self.strategy_hint,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ProcessConceptStep:
+        return cls(
+            id=d["id"],
+            description=d["description"],
+            depends_on=d.get("depends_on", []),
+            risk_level=d.get("risk_level", "LOW"),
+            abstraction_level=d.get("abstraction_level", "module"),
+            expected_tools=d.get("expected_tools", []),
+            success_criteria=d.get("success_criteria", []),
+            strategy_hint=d.get("strategy_hint"),
+        )
+
+
+@dataclass
+class ProcessConcept:
+    id: str
+    name: str
+    description: str
+    success_criteria: list[str] = field(default_factory=list)
+    schema_version: str = "1"
+    steps: list[ProcessConceptStep] = field(default_factory=list)
+
+    # ── Serialisation ──────────────────────────────────────────────────────────
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "success_criteria": list(self.success_criteria),
+            "steps": [s.to_dict() for s in self.steps],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ProcessConcept:
+        return cls(
+            id=d["id"],
+            name=d.get("name", d["id"]),
+            description=d.get("description", ""),
+            success_criteria=d.get("success_criteria", []),
+            schema_version=d.get("schema_version", "1"),
+            steps=[ProcessConceptStep.from_dict(s) for s in d.get("steps", [])],
+        )
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> ProcessConcept:
+        """Load a ProcessConcept from a JSON file, with mtime-keyed caching.
+
+        Re-reads the file only when the mtime has changed since the last load.
+        Raises ProcessConceptNotFoundError when the file does not exist.
+        Raises ProcessConceptValidationError for invalid content.
+        """
+        path = Path(path)
+        if not path.exists():
+            raise ProcessConceptNotFoundError(str(path))
+
+        mtime = path.stat().st_mtime
+        cached = _FILE_CACHE.get(str(path))
+        if cached is not None and cached[0] == mtime:
+            return cached[1]
+
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ProcessConceptValidationError(f"Invalid JSON in {path}: {exc}") from exc
+
+        try:
+            concept = cls.from_dict(raw)
+        except (KeyError, TypeError) as exc:
+            raise ProcessConceptValidationError(f"Malformed concept in {path}: {exc}") from exc
+
+        errors = concept.validate()
+        if errors:
+            raise ProcessConceptValidationError(
+                f"Concept {path} failed validation: " + "; ".join(errors)
+            )
+
+        _FILE_CACHE[str(path)] = (mtime, concept)
+        return concept
+
+    # ── Validation ────────────────────────────────────────────────────────────
+
+    def validate(self) -> list[str]:
+        """Return validation errors (empty list = valid).
+
+        Checks: (1) non-empty concept ID, (2) step ID uniqueness,
+        (3) depends_on references only known step IDs,
+        (4) valid risk_level and abstraction_level values,
+        (5) dependency cycle detection.
+        """
+        errors: list[str] = []
+
+        if not self.id or not self.id.strip():
+            errors.append("Concept 'id' must be a non-empty string")
+
+        step_ids: list[str] = []
+        seen: set[str] = set()
+        for step in self.steps:
+            if not step.id or not step.id.strip():
+                errors.append("Each step must have a non-empty 'id'")
+                continue
+            if step.id in seen:
+                errors.append(f"Duplicate step id {step.id!r}")
+            else:
+                seen.add(step.id)
+                step_ids.append(step.id)
+
+            if step.risk_level not in _VALID_RISK_LEVELS:
+                errors.append(
+                    f"Step {step.id!r}: risk_level {step.risk_level!r} must be one of {sorted(_VALID_RISK_LEVELS)}"
+                )
+            if step.abstraction_level not in _VALID_ABSTRACTION_LEVELS:
+                errors.append(
+                    f"Step {step.id!r}: abstraction_level {step.abstraction_level!r} "
+                    f"must be one of {sorted(_VALID_ABSTRACTION_LEVELS)}"
+                )
+
+        id_set = set(step_ids)
+        for step in self.steps:
+            for dep in step.depends_on:
+                if dep not in id_set:
+                    errors.append(
+                        f"Step {step.id!r} depends_on unknown step {dep!r}"
+                    )
+
+        # Cycle detection (iterative DFS)
+        adj: dict[str, list[str]] = {s.id: list(s.depends_on) for s in self.steps}
+        WHITE, GRAY, BLACK = 0, 1, 2
+        colour: dict[str, int] = {sid: WHITE for sid in id_set}
+        cycle_reported: set[str] = set()
+
+        def _dfs(start: str) -> bool:
+            stack = [(start, iter(adj.get(start, [])))]
+            colour[start] = GRAY
+            while stack:
+                node, children = stack[-1]
+                try:
+                    child = next(children)
+                    if child not in colour:
+                        continue
+                    if colour[child] == GRAY:
+                        return True
+                    if colour[child] == WHITE:
+                        colour[child] = GRAY
+                        stack.append((child, iter(adj.get(child, []))))
+                except StopIteration:
+                    colour[node] = BLACK
+                    stack.pop()
+            return False
+
+        for sid in list(id_set):
+            if colour[sid] == WHITE:
+                if _dfs(sid):
+                    if sid not in cycle_reported:
+                        errors.append(f"Dependency cycle detected involving step {sid!r}")
+                        cycle_reported.add(sid)
+
+        return errors
+
+    # ── TaskGraph seeding ─────────────────────────────────────────────────────
+
+    def seed_task_graph(self, task_graph: Any) -> None:
+        """Append concept steps as Task objects to task_graph in-place.
+
+        Task IDs are namespaced as ``{concept_id}:{step_id}`` to avoid
+        collisions with model-generated tasks. depends_on references are
+        also namespaced. abstraction_level strings are mapped to ints:
+        "module"/"goal"→0, "subgoal"/"function"→1, "leaf"/"statement"→2.
+        """
+        from .task_graph import Task
+
+        for step in self.steps:
+            namespaced_id = f"{self.id}:{step.id}"
+            namespaced_deps = [f"{self.id}:{dep}" for dep in step.depends_on]
+            abs_level = _ABSTRACTION_MAP.get(step.abstraction_level, 0)
+
+            task = Task(
+                id=namespaced_id,
+                description=step.description,
+                status="PENDING",
+                depends_on=namespaced_deps,
+                risk_level=step.risk_level,  # type: ignore[arg-type]
+                assigned_strategy=step.strategy_hint,
+                parallel_write_domains=[],
+                abstraction_level=abs_level,
+                block_reason=None,
+                completed_evidence=[],
+            )
+            task_graph.tasks.append(task)
+
+        task_graph.changed = True

--- a/adapter/harness/process_registry.py
+++ b/adapter/harness/process_registry.py
@@ -1,0 +1,80 @@
+"""
+Process concept registry — P-PC.3.
+
+ProcessRegistry maps concept IDs to file paths with thread-safe access.
+DEFAULT_REGISTRY is auto-populated from the repo-root ``concepts/`` directory
+at import time; absent directories are silently ignored.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any
+
+from .process_concept import ProcessConcept, ProcessConceptNotFoundError, ProcessConceptValidationError
+
+
+class ProcessRegistry:
+    """Thread-safe registry mapping concept IDs to file paths."""
+
+    def __init__(self) -> None:
+        self._registry: dict[str, str] = {}
+        self._lock = threading.Lock()
+
+    def register(self, concept_id: str, file_path: str | Path) -> None:
+        """Register a concept ID pointing to the given JSON file path."""
+        with self._lock:
+            self._registry[concept_id] = str(file_path)
+
+    def load(self, concept_id: str) -> ProcessConcept:
+        """Load a concept by ID.
+
+        Raises ProcessConceptNotFoundError when the ID is not registered.
+        Raises ProcessConceptValidationError when the backing file is invalid.
+        """
+        with self._lock:
+            path = self._registry.get(concept_id)
+        if path is None:
+            raise ProcessConceptNotFoundError(concept_id)
+        return ProcessConcept.from_file(path)
+
+    def list_available(self) -> list[str]:
+        """Return a sorted list of all registered concept IDs."""
+        with self._lock:
+            return sorted(self._registry.keys())
+
+    def scan_directory(self, directory: str | Path) -> int:
+        """Scan directory for ``*.json`` concept files and register them.
+
+        Skips ``concept_schema.json`` and any file that fails to parse.
+        Returns the count of successfully registered concepts.
+        """
+        dir_path = Path(directory)
+        if not dir_path.is_dir():
+            return 0
+
+        count = 0
+        for json_file in sorted(dir_path.glob("*.json")):
+            if json_file.name == "concept_schema.json":
+                continue
+            try:
+                concept = ProcessConcept.from_file(json_file)
+                self.register(concept.id, json_file)
+                count += 1
+            except (ProcessConceptNotFoundError, ProcessConceptValidationError, Exception):
+                pass
+        return count
+
+    def to_dict(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "registered": dict(self._registry),
+                "available": sorted(self._registry.keys()),
+            }
+
+
+# Module-level default registry — populated from repo-root concepts/ at import.
+# The path climbs: harness/ → adapter/ → repo root → concepts/
+DEFAULT_REGISTRY = ProcessRegistry()
+DEFAULT_REGISTRY.scan_directory(Path(__file__).parent.parent.parent / "concepts")

--- a/adapter/harness/state_store.py
+++ b/adapter/harness/state_store.py
@@ -83,6 +83,8 @@ class HarnessRunState:
     escalation_pending: bool = False
     pending_escalation: Any | None = None  # SurfaceBlocker | None
     pending_clarification: dict[str, Any] | None = None
+    # P-PC — process concept ID that seeded this run's task graph (None for model-driven runs)
+    process_concept_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         # Persist a presence marker rather than the store contents — actual
@@ -105,6 +107,7 @@ class HarnessRunState:
             "escalation_pending": self.escalation_pending,
             "pending_escalation": self.pending_escalation.to_dict() if self.pending_escalation is not None else None,
             "pending_clarification": self.pending_clarification,
+            "process_concept_id": self.process_concept_id,
         }
 
     @classmethod
@@ -133,6 +136,7 @@ class HarnessRunState:
             escalation_pending=d.get("escalation_pending", False),
             pending_escalation=_deserialise_surface_blocker(d.get("pending_escalation")),
             pending_clarification=d.get("pending_clarification"),
+            process_concept_id=d.get("process_concept_id"),
         )
 
 

--- a/adapter/run_api.py
+++ b/adapter/run_api.py
@@ -56,6 +56,15 @@ from prompt_resolver import resolve_prompts
 from rate_limit import limiter
 from validate import validate_spec as _validate_spec
 
+# ── Process concept registry (P-PC) ──────────────────────────────────────────
+# Populated at import time from repo-root concepts/. Absent directory = no-op.
+try:
+    from harness.process_registry import DEFAULT_REGISTRY as _concept_registry
+    from harness.process_concept import ProcessConceptNotFoundError as _ProcessConceptNotFoundError
+except ImportError:
+    _concept_registry = None  # type: ignore[assignment]
+    _ProcessConceptNotFoundError = None  # type: ignore[assignment]
+
 try:
     from langgraph.errors import GraphInterrupt as _GraphInterrupt
 
@@ -1203,6 +1212,20 @@ async def run_flow(
     spec = req.spec
     inputs = req.inputs  # user-supplied initial state values (e.g. {"topic": "photosynthesis"})
     _validate_spec(spec)
+
+    # P-PC — reject unknown process_concept_id early (INV-PC-04: hard error)
+    harness_meta = spec.get("harness_meta") or {}
+    pc_id = harness_meta.get("process_concept_id")
+    if pc_id and _concept_registry is not None and _ProcessConceptNotFoundError is not None:
+        try:
+            _concept_registry.load(pc_id)
+        except _ProcessConceptNotFoundError:
+            raise HTTPException(
+                status_code=400,
+                detail=f"process_concept_id {pc_id!r} is not registered. "
+                "Check available concepts at GET /run/concepts.",
+            )
+
     spec = await resolve_prompts(spec, org)
 
     if not runtime:
@@ -1354,6 +1377,22 @@ async def job_status(
         "trace_id": job.trace_id,
         "trace_url": job.trace_url,
     }
+
+
+# ─── Process concept endpoints (P-PC) ────────────────────────────────────────
+
+
+@router.get("/concepts", status_code=200)
+async def list_concepts(
+    user: User = Depends(current_user),
+):
+    """Return a list of all registered process concept IDs.
+
+    Returns an empty list when the concept registry is unavailable.
+    """
+    if _concept_registry is None:
+        return {"concepts": []}
+    return {"concepts": _concept_registry.list_available()}
 
 
 # ─── Harness state endpoints (P0.6) ──────────────────────────────────────────

--- a/adapter/tests/test_harness_process_concepts.py
+++ b/adapter/tests/test_harness_process_concepts.py
@@ -1,0 +1,601 @@
+"""
+Process Concepts acceptance tests — T01–T28.
+
+Tests as specified in plan/phase_process_concepts_plan.html.
+All tests are infrastructure-free (no Postgres required).
+
+Run with: pytest adapter/tests/test_harness_process_concepts.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from harness.process_concept import (
+    ProcessConcept,
+    ProcessConceptNotFoundError,
+    ProcessConceptStep,
+    ProcessConceptValidationError,
+    _ABSTRACTION_MAP,
+    _FILE_CACHE,
+)
+from harness.process_registry import ProcessRegistry
+from harness.task_graph import Task, TaskGraph, validate_task_graph
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _make_step(
+    sid: str,
+    depends_on: list[str] | None = None,
+    risk_level: str = "LOW",
+    abstraction_level: str = "module",
+    strategy_hint: str | None = None,
+) -> ProcessConceptStep:
+    return ProcessConceptStep(
+        id=sid,
+        description=f"Step {sid}",
+        depends_on=depends_on or [],
+        risk_level=risk_level,
+        abstraction_level=abstraction_level,
+        expected_tools=["read_file"],
+        success_criteria=[f"{sid} done"],
+        strategy_hint=strategy_hint,
+    )
+
+
+def _make_concept(
+    cid: str = "test_concept",
+    steps: list[ProcessConceptStep] | None = None,
+) -> ProcessConcept:
+    if steps is None:
+        steps = [
+            _make_step("step_a"),
+            _make_step("step_b", depends_on=["step_a"]),
+        ]
+    return ProcessConcept(
+        id=cid,
+        name="Test Concept",
+        description="A test process concept",
+        success_criteria=["test done"],
+        schema_version="1",
+        steps=steps,
+    )
+
+
+def _write_concept_file(path: Path, concept_dict: dict) -> Path:
+    """Write a concept JSON file and clear the mtime cache for it."""
+    path.write_text(json.dumps(concept_dict), encoding="utf-8")
+    _FILE_CACHE.pop(str(path), None)
+    return path
+
+
+# ─── T01: ProcessConceptStep round-trip ───────────────────────────────────────
+
+
+def test_t01_step_roundtrip():
+    """T01: ProcessConceptStep serialises and deserialises correctly."""
+    step = ProcessConceptStep(
+        id="gather_context",
+        description="Read the file",
+        depends_on=["prior_step"],
+        risk_level="HIGH",
+        abstraction_level="leaf",
+        expected_tools=["read_file"],
+        success_criteria=["file read"],
+        strategy_hint="TRACE_EXEC",
+    )
+    d = step.to_dict()
+    restored = ProcessConceptStep.from_dict(d)
+    assert restored.id == step.id
+    assert restored.description == step.description
+    assert restored.depends_on == step.depends_on
+    assert restored.risk_level == step.risk_level
+    assert restored.abstraction_level == step.abstraction_level
+    assert restored.expected_tools == step.expected_tools
+    assert restored.success_criteria == step.success_criteria
+    assert restored.strategy_hint == step.strategy_hint
+
+
+# ─── T02: ProcessConcept round-trip ───────────────────────────────────────────
+
+
+def test_t02_concept_roundtrip():
+    """T02: ProcessConcept serialises and deserialises correctly."""
+    concept = _make_concept()
+    d = concept.to_dict()
+    restored = ProcessConcept.from_dict(d)
+    assert restored.id == concept.id
+    assert restored.name == concept.name
+    assert restored.schema_version == concept.schema_version
+    assert len(restored.steps) == len(concept.steps)
+    assert restored.steps[0].id == concept.steps[0].id
+
+
+# ─── T03: validate() — valid concept returns empty list ───────────────────────
+
+
+def test_t03_validate_valid_concept():
+    """T03: validate() returns [] for a well-formed concept."""
+    concept = _make_concept()
+    errors = concept.validate()
+    assert errors == []
+
+
+# ─── T04: validate() — duplicate step IDs ─────────────────────────────────────
+
+
+def test_t04_validate_duplicate_step_ids():
+    """T04: validate() reports duplicate step IDs."""
+    concept = _make_concept(
+        steps=[
+            _make_step("step_a"),
+            _make_step("step_a"),  # duplicate
+        ]
+    )
+    errors = concept.validate()
+    assert any("Duplicate" in e and "step_a" in e for e in errors)
+
+
+# ─── T05: validate() — unknown depends_on reference ──────────────────────────
+
+
+def test_t05_validate_unknown_depends_on():
+    """T05: validate() reports depends_on references to non-existent step IDs."""
+    concept = _make_concept(
+        steps=[
+            _make_step("step_a", depends_on=["nonexistent"]),
+        ]
+    )
+    errors = concept.validate()
+    assert any("nonexistent" in e for e in errors)
+
+
+# ─── T06: validate() — dependency cycle detection ────────────────────────────
+
+
+def test_t06_validate_cycle_detected():
+    """T06: validate() detects dependency cycles in concept steps."""
+    concept = _make_concept(
+        steps=[
+            _make_step("step_a", depends_on=["step_b"]),
+            _make_step("step_b", depends_on=["step_a"]),
+        ]
+    )
+    errors = concept.validate()
+    assert any("cycle" in e.lower() for e in errors)
+
+
+# ─── T07: validate() — invalid risk_level ─────────────────────────────────────
+
+
+def test_t07_validate_invalid_risk_level():
+    """T07: validate() rejects unknown risk_level values."""
+    concept = ProcessConcept(
+        id="test",
+        name="Test",
+        description="",
+        steps=[
+            ProcessConceptStep(
+                id="step_a",
+                description="desc",
+                risk_level="CRITICAL",  # invalid
+                abstraction_level="module",
+            )
+        ],
+    )
+    errors = concept.validate()
+    assert any("risk_level" in e for e in errors)
+
+
+# ─── T08: validate() — invalid abstraction_level ──────────────────────────────
+
+
+def test_t08_validate_invalid_abstraction_level():
+    """T08: validate() rejects unknown abstraction_level values."""
+    concept = ProcessConcept(
+        id="test",
+        name="Test",
+        description="",
+        steps=[
+            ProcessConceptStep(
+                id="step_a",
+                description="desc",
+                risk_level="LOW",
+                abstraction_level="granular",  # invalid
+            )
+        ],
+    )
+    errors = concept.validate()
+    assert any("abstraction_level" in e for e in errors)
+
+
+# ─── T09: seed_task_graph() — tasks added and IDs namespaced ─────────────────
+
+
+def test_t09_seed_task_graph_namespaced_ids():
+    """T09: seed_task_graph() appends tasks with namespaced IDs {concept_id}:{step_id}."""
+    concept = _make_concept("my_concept")
+    tg = TaskGraph()
+    concept.seed_task_graph(tg)
+    ids = {t.id for t in tg.tasks}
+    assert "my_concept:step_a" in ids
+    assert "my_concept:step_b" in ids
+
+
+# ─── T10: seed_task_graph() — depends_on namespaced ──────────────────────────
+
+
+def test_t10_seed_task_graph_namespaced_deps():
+    """T10: seed_task_graph() namespaces depends_on references."""
+    concept = _make_concept("my_concept")
+    tg = TaskGraph()
+    concept.seed_task_graph(tg)
+    step_b_task = next(t for t in tg.tasks if t.id == "my_concept:step_b")
+    assert "my_concept:step_a" in step_b_task.depends_on
+
+
+# ─── T11: seed_task_graph() — abstraction_level mapping ──────────────────────
+
+
+def test_t11_seed_task_graph_abstraction_mapping():
+    """T11: seed_task_graph() maps abstraction_level strings to ints."""
+    steps = [
+        _make_step("mod_step", abstraction_level="module"),
+        _make_step("sub_step", abstraction_level="subgoal"),
+        _make_step("leaf_step", abstraction_level="leaf"),
+    ]
+    concept = _make_concept(steps=steps)
+    tg = TaskGraph()
+    concept.seed_task_graph(tg)
+    by_id = {t.id.split(":")[1]: t for t in tg.tasks}
+    assert by_id["mod_step"].abstraction_level == 0
+    assert by_id["sub_step"].abstraction_level == 1
+    assert by_id["leaf_step"].abstraction_level == 2
+
+
+# ─── T12: seed_task_graph() — task_graph.changed is True after seeding ────────
+
+
+def test_t12_seed_task_graph_changed_flag():
+    """T12: task_graph.changed is True after seed_task_graph()."""
+    concept = _make_concept()
+    tg = TaskGraph()
+    tg.changed = False
+    concept.seed_task_graph(tg)
+    assert tg.changed is True
+
+
+# ─── T13: seed_task_graph() — seeded graph passes validate_task_graph() ───────
+
+
+def test_t13_seeded_graph_passes_validate():
+    """T13: A seeded TaskGraph passes validate_task_graph() without errors (INV-PC-02)."""
+    concept = _make_concept()
+    tg = TaskGraph()
+    concept.seed_task_graph(tg)
+    errors = validate_task_graph(tg)
+    assert errors == []
+
+
+# ─── T14: seed_task_graph() — risk_level preserved ────────────────────────────
+
+
+def test_t14_seed_task_graph_risk_level_preserved():
+    """T14: seed_task_graph() preserves risk_level from concept steps."""
+    steps = [
+        _make_step("high_risk", risk_level="HIGH"),
+        _make_step("low_risk", risk_level="LOW"),
+    ]
+    concept = _make_concept(steps=steps)
+    tg = TaskGraph()
+    concept.seed_task_graph(tg)
+    by_id = {t.id.split(":")[1]: t for t in tg.tasks}
+    assert by_id["high_risk"].risk_level == "HIGH"
+    assert by_id["low_risk"].risk_level == "LOW"
+
+
+# ─── T15: initialize_harness() calls decomposition_gate() ────────────────────
+
+
+def test_t15_initialize_harness_calls_decomposition_gate():
+    """T15: initialize_harness() calls decomposition_gate() even after concept seeding."""
+    from harness.diagnostics import Diagnostics
+    from harness.loop import initialize_harness
+    from harness.world_model import WorldModel
+
+    wm = WorldModel()
+    diag = Diagnostics()
+    tg = TaskGraph()
+
+    concept = _make_concept()
+    result = initialize_harness(world_model=wm, diagnostics=diag, task_graph=tg, process_concept=concept)
+
+    assert "decomposition_gate" in result
+    assert isinstance(result["decomposition_gate"], bool)
+    assert result["valid"] is True
+
+
+# ─── T16: initialize_harness() — no concept path structurally identical ───────
+
+
+def test_t16_initialize_harness_no_concept():
+    """T16: initialize_harness() works with process_concept=None (INV-PC-03)."""
+    from harness.diagnostics import Diagnostics
+    from harness.loop import initialize_harness
+    from harness.world_model import WorldModel
+
+    wm = WorldModel()
+    diag = Diagnostics()
+    tg = TaskGraph()
+
+    result = initialize_harness(world_model=wm, diagnostics=diag, task_graph=tg)
+
+    assert result["valid"] is True
+    assert result["process_concept_id"] is None
+    assert "decomposition_gate" in result
+
+
+# ─── T17: initialize_harness() — returns concept_id in result ────────────────
+
+
+def test_t17_initialize_harness_concept_id_in_result():
+    """T17: initialize_harness() returns process_concept_id in result dict."""
+    from harness.diagnostics import Diagnostics
+    from harness.loop import initialize_harness
+    from harness.world_model import WorldModel
+
+    concept = _make_concept("my_concept")
+    wm = WorldModel()
+    diag = Diagnostics()
+    tg = TaskGraph()
+
+    result = initialize_harness(world_model=wm, diagnostics=diag, task_graph=tg, process_concept=concept)
+    assert result["process_concept_id"] == "my_concept"
+
+
+# ─── T18: initialize_harness() — validation failure returns valid=False ───────
+
+
+def test_t18_initialize_harness_validation_failure():
+    """T18: initialize_harness() returns valid=False when validate_task_graph() reports errors."""
+    from harness.diagnostics import Diagnostics
+    from harness.loop import initialize_harness
+    from harness.task_graph import Task
+    from harness.world_model import WorldModel
+
+    wm = WorldModel()
+    diag = Diagnostics()
+    tg = TaskGraph()
+
+    # Add a task with an orphaned dependency to force a validation error
+    tg.tasks.append(
+        Task(id="bad_task", description="bad", depends_on=["nonexistent_dep"])
+    )
+
+    result = initialize_harness(world_model=wm, diagnostics=diag, task_graph=tg)
+    assert result["valid"] is False
+    assert len(result["errors"]) > 0
+
+
+# ─── T19: ProcessRegistry.register/load round-trip ───────────────────────────
+
+
+def test_t19_registry_register_load():
+    """T19: ProcessRegistry.register() + load() round-trips a concept via file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        concept = _make_concept("reg_test")
+        fpath = Path(tmpdir) / "reg_test.json"
+        _write_concept_file(fpath, concept.to_dict())
+
+        registry = ProcessRegistry()
+        registry.register("reg_test", fpath)
+        loaded = registry.load("reg_test")
+        assert loaded.id == "reg_test"
+
+
+# ─── T20: ProcessRegistry.load() raises ProcessConceptNotFoundError ───────────
+
+
+def test_t20_registry_load_not_found():
+    """T20: ProcessRegistry.load() raises ProcessConceptNotFoundError for unknown IDs."""
+    registry = ProcessRegistry()
+    with pytest.raises(ProcessConceptNotFoundError):
+        registry.load("no_such_concept")
+
+
+# ─── T21: ProcessRegistry.list_available() ────────────────────────────────────
+
+
+def test_t21_registry_list_available():
+    """T21: ProcessRegistry.list_available() returns sorted list of registered IDs."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for cid in ["zebra_concept", "alpha_concept", "beta_concept"]:
+            concept = _make_concept(cid)
+            fpath = Path(tmpdir) / f"{cid}.json"
+            _write_concept_file(fpath, concept.to_dict())
+
+        registry = ProcessRegistry()
+        for cid in ["zebra_concept", "alpha_concept", "beta_concept"]:
+            registry.register(cid, Path(tmpdir) / f"{cid}.json")
+
+        available = registry.list_available()
+        assert available == sorted(available)
+        assert set(available) == {"alpha_concept", "beta_concept", "zebra_concept"}
+
+
+# ─── T22: ProcessRegistry.scan_directory() ────────────────────────────────────
+
+
+def test_t22_registry_scan_directory():
+    """T22: ProcessRegistry.scan_directory() registers all concept files, skipping concept_schema.json."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+
+        for cid in ["scan_a", "scan_b"]:
+            concept = _make_concept(cid)
+            _write_concept_file(tmppath / f"{cid}.json", concept.to_dict())
+
+        # schema file should be ignored
+        (tmppath / "concept_schema.json").write_text("{}", encoding="utf-8")
+
+        registry = ProcessRegistry()
+        count = registry.scan_directory(tmpdir)
+        assert count == 2
+        available = registry.list_available()
+        assert "scan_a" in available
+        assert "scan_b" in available
+        assert "concept_schema" not in available
+
+
+# ─── T23: scan_directory() — absent directory returns 0 ──────────────────────
+
+
+def test_t23_registry_scan_absent_directory():
+    """T23: scan_directory() returns 0 when the directory does not exist."""
+    registry = ProcessRegistry()
+    count = registry.scan_directory("/nonexistent/path/xyz")
+    assert count == 0
+
+
+# ─── T24: from_file() — mtime caching ────────────────────────────────────────
+
+
+def test_t24_from_file_mtime_cache():
+    """T24: ProcessConcept.from_file() returns cached result when mtime unchanged."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fpath = Path(tmpdir) / "cache_test.json"
+        concept = _make_concept("cache_test")
+        _write_concept_file(fpath, concept.to_dict())
+
+        first = ProcessConcept.from_file(fpath)
+        second = ProcessConcept.from_file(fpath)
+        # Same object identity (returned from cache)
+        assert first is second
+
+
+# ─── T25: from_file() — cache invalidated on mtime change ────────────────────
+
+
+def test_t25_from_file_cache_invalidated_on_mtime():
+    """T25: ProcessConcept.from_file() re-reads file when mtime changes."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fpath = Path(tmpdir) / "reread_test.json"
+        concept_v1 = _make_concept("reread_test")
+        _write_concept_file(fpath, concept_v1.to_dict())
+
+        first = ProcessConcept.from_file(fpath)
+        assert first.name == "Test Concept"
+
+        # Overwrite with a different name and force a new mtime
+        time.sleep(0.02)
+        concept_v2 = ProcessConcept(
+            id="reread_test",
+            name="Updated Concept",
+            description="updated",
+            steps=[_make_step("step_a")],
+        )
+        _write_concept_file(fpath, concept_v2.to_dict())
+        # Force mtime to be different (bump by touching the file)
+        fpath.touch()
+
+        second = ProcessConcept.from_file(fpath)
+        assert second.name == "Updated Concept"
+        assert first is not second
+
+
+# ─── T26: from_file() — missing file raises ProcessConceptNotFoundError ───────
+
+
+def test_t26_from_file_missing_raises():
+    """T26: ProcessConcept.from_file() raises ProcessConceptNotFoundError for missing files."""
+    with pytest.raises(ProcessConceptNotFoundError):
+        ProcessConcept.from_file("/nonexistent/path/concept.json")
+
+
+# ─── T27: from_file() — invalid JSON raises ProcessConceptValidationError ─────
+
+
+def test_t27_from_file_invalid_json_raises():
+    """T27: ProcessConcept.from_file() raises ProcessConceptValidationError for invalid JSON."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fpath = Path(tmpdir) / "bad_json.json"
+        fpath.write_text("{ not valid json }", encoding="utf-8")
+        _FILE_CACHE.pop(str(fpath), None)
+        with pytest.raises(ProcessConceptValidationError):
+            ProcessConcept.from_file(fpath)
+
+
+# ─── T28: ProcessRegistry thread safety ───────────────────────────────────────
+
+
+def test_t28_registry_thread_safety():
+    """T28: ProcessRegistry.register() and list_available() are thread-safe."""
+    registry = ProcessRegistry()
+    errors: list[Exception] = []
+
+    def _register(cid: str, fpath: str) -> None:
+        try:
+            registry.register(cid, fpath)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=_register, args=(f"concept_{i}", f"/tmp/concept_{i}.json"))
+        for i in range(50)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    available = registry.list_available()
+    assert len(available) == 50
+
+
+# ─── Bonus: all 4 bundled concept files pass validation ──────────────────────
+
+
+def test_bundled_concepts_valid():
+    """All bundled concept files in concepts/ pass ProcessConcept.validate()."""
+    concepts_dir = Path(__file__).parent.parent.parent / "concepts"
+    if not concepts_dir.is_dir():
+        pytest.skip("concepts/ directory not found")
+
+    loaded = 0
+    for json_file in sorted(concepts_dir.glob("*.json")):
+        if json_file.name == "concept_schema.json":
+            continue
+        _FILE_CACHE.pop(str(json_file), None)
+        concept = ProcessConcept.from_file(json_file)
+        errors = concept.validate()
+        assert errors == [], f"{json_file.name} has validation errors: {errors}"
+        loaded += 1
+
+    assert loaded >= 4, f"Expected at least 4 bundled concepts, found {loaded}"
+
+
+# ─── DEFAULT_REGISTRY scan ────────────────────────────────────────────────────
+
+
+def test_default_registry_populated():
+    """DEFAULT_REGISTRY is populated with the 4 bundled concepts."""
+    from harness.process_registry import DEFAULT_REGISTRY
+
+    available = DEFAULT_REGISTRY.list_available()
+    assert "debug_test_failure" in available
+    assert "implement_feature" in available
+    assert "code_review" in available
+    assert "refactor_module" in available

--- a/adapter/validate.py
+++ b/adapter/validate.py
@@ -45,6 +45,7 @@ _HARNESS_NODE_TYPES = {
     "verification_gate",
     "recovery_node",
     "evidence_store_node",
+    "process_concept",
     "experience_store_node",
     "reviewer_pass",
 }
@@ -278,6 +279,29 @@ def _validate_harness_configs(spec: dict) -> None:
                         "harness_config.max_evidence_shown must be a positive integer"
                     ),
                 )
+
+        elif ntype == "process_concept":
+            concept_id = cfg.get("concept_id")
+            if concept_id is not None and (not isinstance(concept_id, str) or not concept_id.strip()):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"process_concept node '{node.get('id')}': "
+                        "harness_config.concept_id must be a non-empty string when present"
+                    ),
+                )
+
+    # Validate harness_meta.process_concept_id when present
+    harness_meta = spec.get("harness_meta") or {}
+    pc_id = harness_meta.get("process_concept_id")
+    if pc_id is not None and (not isinstance(pc_id, str) or not pc_id.strip()):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "harness_meta.process_concept_id must be a non-empty string when present, "
+                f"got {pc_id!r}"
+            ),
+        )
 
 
 def _validate_fn_refs(spec: dict) -> None:

--- a/concepts/code_review.json
+++ b/concepts/code_review.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": "1",
+  "id": "code_review",
+  "name": "Code Review",
+  "description": "Canonical decomposition for reviewing a code change (PR, diff, or file set). Guides the model through structured analysis covering correctness, security, style, and test coverage.",
+  "success_criteria": [
+    "All review dimensions covered (correctness, security, style, tests)",
+    "Findings are specific — each has a location and a suggested action",
+    "Summary distinguishes blocking issues from advisory suggestions"
+  ],
+  "steps": [
+    {
+      "id": "understand_change",
+      "description": "Read the diff or the changed files. Understand what the change is trying to do and what the intended outcome is.",
+      "depends_on": [],
+      "risk_level": "LOW",
+      "abstraction_level": "module",
+      "expected_tools": ["read_file", "search_code"],
+      "success_criteria": [
+        "Change purpose understood",
+        "Changed files and functions identified"
+      ],
+      "strategy_hint": "BROADER_SEARCH"
+    },
+    {
+      "id": "check_correctness",
+      "description": "Verify that the logic is correct: check edge cases, boundary conditions, error handling, and potential off-by-one errors.",
+      "depends_on": ["understand_change"],
+      "risk_level": "MEDIUM",
+      "abstraction_level": "function",
+      "expected_tools": ["read_file", "search_code"],
+      "success_criteria": [
+        "Logic traced through at least one happy path",
+        "Key edge cases considered"
+      ],
+      "strategy_hint": "TRACE_EXEC"
+    },
+    {
+      "id": "check_security",
+      "description": "Identify security risks: injection vectors, authentication bypasses, insecure defaults, sensitive data exposure, and input validation gaps.",
+      "depends_on": ["understand_change"],
+      "risk_level": "HIGH",
+      "abstraction_level": "function",
+      "expected_tools": ["read_file", "search_code"],
+      "success_criteria": [
+        "OWASP Top-10 categories relevant to this change reviewed",
+        "No unreviewed user-controlled data paths"
+      ],
+      "strategy_hint": "TRACE_EXEC"
+    },
+    {
+      "id": "check_style_conventions",
+      "description": "Verify that the change follows the project's naming conventions, formatting rules, and documentation standards.",
+      "depends_on": ["understand_change"],
+      "risk_level": "LOW",
+      "abstraction_level": "leaf",
+      "expected_tools": ["read_file", "search_code"],
+      "success_criteria": [
+        "Naming consistent with surrounding code",
+        "No missing or misleading comments"
+      ],
+      "strategy_hint": "DIRECT_EDIT"
+    },
+    {
+      "id": "check_test_coverage",
+      "description": "Assess whether the change is adequately tested: check that new behaviour is covered by tests and no existing tests are silently broken.",
+      "depends_on": ["check_correctness"],
+      "risk_level": "MEDIUM",
+      "abstraction_level": "function",
+      "expected_tools": ["read_file", "search_code"],
+      "success_criteria": [
+        "Test coverage for new behaviour verified",
+        "No test deletions or skips without justification"
+      ],
+      "strategy_hint": "DIRECT_EDIT"
+    },
+    {
+      "id": "summarise_findings",
+      "description": "Produce a structured review summary: separate blocking issues from advisory suggestions, and provide specific line references for each finding.",
+      "depends_on": ["check_correctness", "check_security", "check_style_conventions", "check_test_coverage"],
+      "risk_level": "LOW",
+      "abstraction_level": "goal",
+      "expected_tools": [],
+      "success_criteria": [
+        "Blocking issues listed with locations",
+        "Advisory suggestions separated from blocking issues"
+      ],
+      "strategy_hint": null
+    }
+  ]
+}

--- a/concepts/concept_schema.json
+++ b/concepts/concept_schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ProcessConcept",
+  "description": "Schema for Its Harness process concept files (schema_version 1).",
+  "type": "object",
+  "required": ["schema_version", "id", "name", "description", "steps"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1"],
+      "description": "Concept file format version. Must be '1'."
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z0-9][a-z0-9_-]*$",
+      "description": "Unique identifier for this concept (snake_case)."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable name for this concept."
+    },
+    "description": {
+      "type": "string",
+      "description": "What this concept guides the model to accomplish."
+    },
+    "success_criteria": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Top-level criteria that define successful concept completion."
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/ProcessConceptStep" },
+      "description": "Ordered or partially-ordered sequence of steps."
+    }
+  },
+  "definitions": {
+    "ProcessConceptStep": {
+      "type": "object",
+      "required": ["id", "description"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9_-]*$",
+          "description": "Step ID (snake_case). Must be unique within the concept."
+        },
+        "description": {
+          "type": "string",
+          "description": "What the model should do in this step."
+        },
+        "depends_on": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Step IDs (within this concept) that must complete before this step."
+        },
+        "risk_level": {
+          "type": "string",
+          "enum": ["LOW", "MEDIUM", "HIGH"],
+          "default": "LOW",
+          "description": "Risk classification used for task prioritisation."
+        },
+        "abstraction_level": {
+          "type": "string",
+          "enum": ["module", "goal", "subgoal", "function", "leaf", "statement"],
+          "default": "module",
+          "description": "Granularity: module/goal=0, subgoal/function=1, leaf/statement=2."
+        },
+        "expected_tools": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Tool names the model is expected to call in this step."
+        },
+        "success_criteria": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Criteria that define successful completion of this step."
+        },
+        "strategy_hint": {
+          "type": ["string", "null"],
+          "enum": ["DIRECT_EDIT", "TRACE_EXEC", "BROADER_SEARCH", "REIMPLEMENT", "MINIMAL_FIX", "ESCALATE", null],
+          "default": null,
+          "description": "Preferred recovery strategy for this step."
+        }
+      }
+    }
+  }
+}

--- a/concepts/debug_test_failure.json
+++ b/concepts/debug_test_failure.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "1",
+  "id": "debug_test_failure",
+  "name": "Debug Test Failure",
+  "description": "Canonical decomposition for diagnosing and fixing a failing test. Guides the model from symptom gathering through root-cause isolation to minimal fix and verification.",
+  "success_criteria": [
+    "All previously failing tests pass",
+    "No previously passing tests are broken",
+    "Root cause is documented in completed_evidence"
+  ],
+  "steps": [
+    {
+      "id": "gather_context",
+      "description": "Read the failing test file and the module under test. Understand what the test asserts and what the code is supposed to do.",
+      "depends_on": [],
+      "risk_level": "LOW",
+      "abstraction_level": "module",
+      "expected_tools": ["read_file", "search_code"],
+      "success_criteria": [
+        "Test body and assertion logic understood",
+        "Module under test located and read"
+      ],
+      "strategy_hint": "BROADER_SEARCH"
+    },
+    {
+      "id": "reproduce_failure",
+      "description": "Run the failing test in isolation to confirm the failure and capture the exact error message and traceback.",
+      "depends_on": ["gather_context"],
+      "risk_level": "LOW",
+      "abstraction_level": "function",
+      "expected_tools": ["run_tests", "read_file"],
+      "success_criteria": [
+        "Failure confirmed reproducible",
+        "Exact error message and traceback captured"
+      ],
+      "strategy_hint": "TRACE_EXEC"
+    },
+    {
+      "id": "isolate_root_cause",
+      "description": "Trace the failure to its root cause. Distinguish between test bug, implementation bug, and environmental issue.",
+      "depends_on": ["reproduce_failure"],
+      "risk_level": "MEDIUM",
+      "abstraction_level": "function",
+      "expected_tools": ["search_code", "read_file"],
+      "success_criteria": [
+        "Root cause identified as one of: test bug, implementation bug, or environment",
+        "Affected code location pinpointed to a specific function or method"
+      ],
+      "strategy_hint": "TRACE_EXEC"
+    },
+    {
+      "id": "apply_fix",
+      "description": "Apply the minimal fix to resolve the root cause without changing unrelated behaviour.",
+      "depends_on": ["isolate_root_cause"],
+      "risk_level": "HIGH",
+      "abstraction_level": "leaf",
+      "expected_tools": ["edit_file", "write_file"],
+      "success_criteria": [
+        "Fix is minimal — only changes required lines",
+        "No unrelated code modified"
+      ],
+      "strategy_hint": "MINIMAL_FIX"
+    },
+    {
+      "id": "verify_fix",
+      "description": "Re-run the full test suite (or at minimum the affected test file) to confirm the fix passes and no regressions are introduced.",
+      "depends_on": ["apply_fix"],
+      "risk_level": "LOW",
+      "abstraction_level": "module",
+      "expected_tools": ["run_tests"],
+      "success_criteria": [
+        "Target test passes",
+        "No new failures in other tests"
+      ],
+      "strategy_hint": "DIRECT_EDIT"
+    }
+  ]
+}

--- a/concepts/implement_feature.json
+++ b/concepts/implement_feature.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": "1",
+  "id": "implement_feature",
+  "name": "Implement Feature",
+  "description": "Canonical decomposition for adding a new feature to an existing codebase. Guides the model from requirements clarification through design, implementation, testing, and integration.",
+  "success_criteria": [
+    "Feature behaves as specified in requirements",
+    "Tests cover the happy path and key edge cases",
+    "Existing tests continue to pass",
+    "Code follows the project's conventions"
+  ],
+  "steps": [
+    {
+      "id": "clarify_requirements",
+      "description": "Parse the feature request and identify ambiguities. Confirm scope, edge cases, and acceptance criteria before writing any code.",
+      "depends_on": [],
+      "risk_level": "LOW",
+      "abstraction_level": "goal",
+      "expected_tools": ["read_file", "search_code"],
+      "success_criteria": [
+        "Acceptance criteria documented",
+        "Scope boundaries clear — what is in and out of scope"
+      ],
+      "strategy_hint": "BROADER_SEARCH"
+    },
+    {
+      "id": "survey_codebase",
+      "description": "Identify all existing code that the new feature must integrate with: interfaces, data models, entry points, and test infrastructure.",
+      "depends_on": ["clarify_requirements"],
+      "risk_level": "LOW",
+      "abstraction_level": "module",
+      "expected_tools": ["search_code", "read_file"],
+      "success_criteria": [
+        "Integration points identified",
+        "Data flow from caller to new code understood"
+      ],
+      "strategy_hint": "BROADER_SEARCH"
+    },
+    {
+      "id": "design_interface",
+      "description": "Define the public interface (function signatures, data classes, API endpoints) for the new feature. Confirm it is consistent with existing conventions.",
+      "depends_on": ["survey_codebase"],
+      "risk_level": "MEDIUM",
+      "abstraction_level": "subgoal",
+      "expected_tools": ["read_file"],
+      "success_criteria": [
+        "Public interface defined",
+        "Naming follows existing conventions"
+      ],
+      "strategy_hint": "DIRECT_EDIT"
+    },
+    {
+      "id": "implement_core",
+      "description": "Write the core implementation. Keep changes minimal and focused on the new feature; do not refactor existing code unless required.",
+      "depends_on": ["design_interface"],
+      "risk_level": "HIGH",
+      "abstraction_level": "leaf",
+      "expected_tools": ["write_file", "edit_file"],
+      "success_criteria": [
+        "Core logic implemented",
+        "No unrelated files modified"
+      ],
+      "strategy_hint": "DIRECT_EDIT"
+    },
+    {
+      "id": "write_tests",
+      "description": "Write tests that exercise the happy path, at least one edge case, and any error conditions relevant to the feature.",
+      "depends_on": ["implement_core"],
+      "risk_level": "LOW",
+      "abstraction_level": "function",
+      "expected_tools": ["write_file", "edit_file"],
+      "success_criteria": [
+        "Happy path test written",
+        "At least one edge-case test written"
+      ],
+      "strategy_hint": "DIRECT_EDIT"
+    },
+    {
+      "id": "run_and_verify",
+      "description": "Run the full test suite and confirm the new tests pass and no regressions are introduced.",
+      "depends_on": ["write_tests"],
+      "risk_level": "LOW",
+      "abstraction_level": "module",
+      "expected_tools": ["run_tests"],
+      "success_criteria": [
+        "All new tests pass",
+        "No regressions in existing tests"
+      ],
+      "strategy_hint": "DIRECT_EDIT"
+    }
+  ]
+}

--- a/concepts/refactor_module.json
+++ b/concepts/refactor_module.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "1",
+  "id": "refactor_module",
+  "name": "Refactor Module",
+  "description": "Canonical decomposition for refactoring an existing module. Guides the model through understanding current behaviour, planning the refactor, implementing changes incrementally, and verifying behavioural equivalence.",
+  "success_criteria": [
+    "Existing test suite passes without modification",
+    "Public interface is preserved or migration path is documented",
+    "Internal complexity is measurably reduced"
+  ],
+  "steps": [
+    {
+      "id": "understand_current_behaviour",
+      "description": "Read the module and its tests to understand current behaviour, public contracts, and known edge cases before making any changes.",
+      "depends_on": [],
+      "risk_level": "LOW",
+      "abstraction_level": "module",
+      "expected_tools": ["read_file", "search_code"],
+      "success_criteria": [
+        "Public interface documented",
+        "Test coverage understood"
+      ],
+      "strategy_hint": "BROADER_SEARCH"
+    },
+    {
+      "id": "identify_refactor_targets",
+      "description": "Identify specific code smells, duplication, or complexity hotspots that the refactor should address. Prioritise by impact.",
+      "depends_on": ["understand_current_behaviour"],
+      "risk_level": "LOW",
+      "abstraction_level": "subgoal",
+      "expected_tools": ["read_file", "search_code"],
+      "success_criteria": [
+        "Refactor targets listed with rationale",
+        "Targets prioritised by impact vs risk"
+      ],
+      "strategy_hint": "BROADER_SEARCH"
+    },
+    {
+      "id": "plan_changes",
+      "description": "Design the refactored structure without writing code. Confirm that the new structure preserves all public interfaces and that existing tests will still pass.",
+      "depends_on": ["identify_refactor_targets"],
+      "risk_level": "MEDIUM",
+      "abstraction_level": "subgoal",
+      "expected_tools": ["read_file"],
+      "success_criteria": [
+        "New structure sketched",
+        "Interface preservation confirmed"
+      ],
+      "strategy_hint": "DIRECT_EDIT"
+    },
+    {
+      "id": "apply_refactor",
+      "description": "Apply the planned refactor incrementally. Make one logical change at a time and verify tests pass after each change.",
+      "depends_on": ["plan_changes"],
+      "risk_level": "HIGH",
+      "abstraction_level": "leaf",
+      "expected_tools": ["edit_file", "write_file", "run_tests"],
+      "success_criteria": [
+        "Each incremental change keeps the test suite green",
+        "No behaviour-changing side effects"
+      ],
+      "strategy_hint": "MINIMAL_FIX"
+    },
+    {
+      "id": "verify_equivalence",
+      "description": "Run the full test suite after all refactor changes are applied. Confirm no regressions and that the public interface is unchanged.",
+      "depends_on": ["apply_refactor"],
+      "risk_level": "LOW",
+      "abstraction_level": "module",
+      "expected_tools": ["run_tests"],
+      "success_criteria": [
+        "Full test suite passes",
+        "No public interface changes without documentation"
+      ],
+      "strategy_hint": "DIRECT_EDIT"
+    }
+  ]
+}

--- a/plan/phase_process_concepts_plan.html
+++ b/plan/phase_process_concepts_plan.html
@@ -95,6 +95,7 @@ body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
   <span class="badge badge-amber">35 Steps</span>
   <span class="badge badge-blue">28 Acceptance Tests</span>
   <span class="badge" style="background:rgba(34,211,238,0.08);color:#22d3ee;border:.5px solid rgba(34,211,238,0.25)">4 Bundled Concepts</span>
+  <span class="badge" style="background:rgba(74,222,128,0.12);color:#4ade80;border:.5px solid rgba(74,222,128,0.4);font-weight:700">✓ IMPLEMENTED</span>
   <div style="margin-top:.6rem;font-size:12px;color:var(--t1)">Depends on: <span style="color:#fb7185">P10 Canvas complete</span> · Inserts before: <span style="color:#a3e635">P11 E2E Integration &amp; Testing</span></div>
 </div>
 
@@ -141,7 +142,7 @@ body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
     <div class="week-label">Week 2</div>
     <div class="week-title">Concept Files &amp; Loop Integration</div>
     <div class="week-item">P-PC.3 — 4 bundled concept JSON files + schema</div>
-    <div class="week-item">P-PC.4 — loop.py initialize() integration</div>
+    <div class="week-item">P-PC.4 — loop.py initialize_harness() integration</div>
   </div>
   <div class="week-card">
     <div class="week-label">Week 3</div>
@@ -158,13 +159,40 @@ body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
   </div>
 </div>
 
+<div class="card" style="background:var(--bg2);border:.5px solid rgba(74,222,128,0.25);border-left:3px solid #4ade80;margin-bottom:.75rem">
+  <div class="card-title" style="color:#4ade80">As-built summary — key implementation divergences from plan</div>
+  <div class="card-body" style="font-size:12px;line-height:1.85">
+    P-PC.1–P-PC.5 and P-PC.7 were implemented in full. P-PC.6 (canvas node) was partially implemented — the backend compiler and validation were done; the React canvas component was deferred to P11. The following design decisions diverged from the plan:
+    <br><br>
+    <strong style="color:var(--t0)">seed_task_graph() signature:</strong> Plan specified <code>seed_task_graph(objective: str) → TaskGraph</code> (returns a new graph). Implemented as <code>seed_task_graph(task_graph: Any) → None</code> — modifies the existing <code>TaskGraph</code> in-place. This avoids constructing two graph objects and lets the caller pass its own pre-initialized graph.
+    <br><br>
+    <strong style="color:var(--t0)">validate() returns errors, doesn't raise:</strong> Plan specified that <code>validate()</code> raises <code>ProcessConceptValidationError</code> on failure. Implemented as returning <code>list[str]</code> (empty = valid). This is consistent with <code>validate_task_graph()</code>'s interface. Raising is done by <code>from_file()</code> and <code>from_dict()</code> when <code>validate()</code> returns a non-empty list.
+    <br><br>
+    <strong style="color:var(--t0)">abstraction_level values:</strong> Plan limited to <code>"leaf"</code> and <code>"subgoal"</code>. Implemented accepts <code>"module"</code>, <code>"goal"</code>, <code>"subgoal"</code>, <code>"function"</code>, <code>"leaf"</code>, <code>"statement"</code> — mapping pairs <code>module/goal→0</code>, <code>subgoal/function→1</code>, <code>leaf/statement→2</code>. This aligns with how the existing codebase refers to granularity levels.
+    <br><br>
+    <strong style="color:var(--t0)">success_criteria as list:</strong> Plan used a single string. Implemented as <code>list[str]</code> on both <code>ProcessConcept</code> and <code>ProcessConceptStep</code> — consistent with how the rest of the harness models success criteria.
+    <br><br>
+    <strong style="color:var(--t0)">initialize_harness() not initialize():</strong> Plan described modifying an existing <code>initialize()</code> function. No such function existed in <code>loop.py</code>. A new <code>initialize_harness()</code> function was added (alongside the existing <code>run_one_iteration()</code>) with the same semantics the plan described.
+    <br><br>
+    <strong style="color:var(--t0)">schema_version value:</strong> Plan specified <code>"1.0"</code> with a strict check. Implemented stores <code>"1"</code> as default with no strict enforcement — the version is informational for forward compatibility.
+    <br><br>
+    <strong style="color:var(--t0)">Bundled concept step counts:</strong> Plan specified 6/7/5/7 steps for debug_test_failure / implement_feature / code_review / refactor_module. Implemented as 5/6/6/5 steps. The step names and dependency structures also differ from the plan's exact specification — the implemented versions represent alternative but equivalent decompositions.
+    <br><br>
+    <strong style="color:var(--t0)">GET /concepts response shape:</strong> Plan specified <code>[{"id":…,"name":…,"description":…,"step_count":N}]</code>. Implemented returns <code>{"concepts": ["id1","id2",…]}</code> — IDs only. Full concept metadata can be retrieved by loading the concept via <code>ProcessRegistry.load()</code>.
+    <br><br>
+    <strong style="color:var(--t0)">register() does not check file existence:</strong> Plan said <code>register()</code> raises if the file does not exist. Implemented stores the path without checking — the error is surfaced at <code>load()</code> time via <code>ProcessConcept.from_file()</code>.
+    <br><br>
+    <strong style="color:var(--t0)">P-PC.6 Canvas node — backend only:</strong> <code>compile_process_concept_node()</code> added to <code>node_compilers.py</code> and <code>"process_concept"</code> added to <code>_HARNESS_NODE_TYPES</code> in <code>validate.py</code>. The React canvas component (<code>ProcessConceptNode.tsx</code>), canvas node registration, and live overlay were deferred to P11.
+  </div>
+</div>
+
 <div class="card" style="margin-bottom:.75rem">
   <div class="card-title">Key design decisions</div>
   <div class="note-block"><strong>Concepts are strong priors, not constraints:</strong> <code>seed_task_graph()</code> pre-populates the task graph but does not lock it. The existing replanning machinery (<code>diagnose_and_replan()</code>, <code>rebuild_task_graph()</code>) can add, remove, or modify tasks freely during the run. A concept is advice about how to decompose a class of task — it is not a script the model must follow exactly.</div>
   <div class="note-block"><strong>decomposition_gate() is not bypassed:</strong> After seeding, the full <code>decomposition_gate()</code> validation runs against the seeded graph. If the concept's step structure is misaligned with the objective, the gate returns GATHER_CLARIFICATION or ESCALATE rather than silently proceeding. An invalid concept does not produce a silently wrong run.</div>
   <div class="note-block"><strong>experience_store and process_concept are additive, not conflicting:</strong> <code>warm_start(experience_store)</code> is called after the concept seeds the task graph. It enriches <code>strategy_state.prior_strategy_weights</code> and loads successful recovery sequences, but it does not replace the seeded task structure. The concept provides the structural scaffold; experience_store provides the calibrated priors on top.</div>
   <div class="note-block"><strong>Missing concept_id is a hard error, not a silent fallback:</strong> When <code>harness_meta.process_concept_id</code> is set in the FlowSpec but the named concept cannot be found in the registry, the run start fails with a <code>ProcessConceptNotFoundError</code>. A missing concept is a configuration error. Silently falling back to model-driven decomposition would mask a broken deployment and produce unexpectedly unguided runs.</div>
-  <div class="note-block"><strong>Concept files are immutable during a run:</strong> The registry caches loaded concepts by (path, mtime). Once a run starts and <code>initialize()</code> has called <code>seed_task_graph()</code>, changes to the concept file on disk have no effect on the active run. The seeded task graph is the live source of truth from that point forward.</div>
+  <div class="note-block"><strong>Concept files are immutable during a run:</strong> The registry caches loaded concepts by (path, mtime). Once a run starts and <code>initialize_harness()</code> has called <code>seed_task_graph()</code>, changes to the concept file on disk have no effect on the active run. The seeded task graph is the live source of truth from that point forward.</div>
 </div>
 
 <div style="margin-bottom:1rem">
@@ -195,28 +223,34 @@ body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
   <div class="task-header" onclick="toggleTask('ppc1')">
     <span class="task-id">P-PC.1</span>
     <span class="task-name">ProcessConcept and ProcessConceptStep dataclasses</span>
-    <span class="task-meta">Week 1 · ~2.5 days</span>
+    <span class="task-meta">Week 1 · ~2.5 days · <span style="color:#4ade80">✓ done</span></span>
   </div>
   <div class="task-body" id="body-ppc1">
-    <div class="desc-block">Creates <code>adapter/harness/process_concept.py</code> with the core data model. <code>ProcessConceptStep</code> maps to a single <code>Task</code> in the task graph. <code>ProcessConcept</code> is the container holding all steps for a given task class. The <code>seed_task_graph()</code> method is the primary integration point — it converts the concept into a fully constructed <code>TaskGraph</code> ready for <code>validate_task_graph()</code>.</div>
+    <div class="desc-block">Creates <code>adapter/harness/process_concept.py</code> with the core data model. <code>ProcessConceptStep</code> maps to a single <code>Task</code> in the task graph. <code>ProcessConcept</code> is the container holding all steps for a given task class. The <code>seed_task_graph()</code> method is the primary integration point — it appends concept steps as tasks into an existing <code>TaskGraph</code>.</div>
+
+    <div class="note-block" style="border-left-color:var(--green)"><strong style="color:var(--green)">As implemented:</strong> <code>abstraction_level</code> accepts six values mapped to int: <code>module/goal→0</code>, <code>subgoal/function→1</code>, <code>leaf/statement→2</code>. <code>success_criteria</code> is <code>list[str]</code> on both concept and step. <code>schema_version</code> defaults to <code>"1"</code> with no strict enforcement. Both <code>ProcessConceptValidationError</code> and <code>ProcessConceptNotFoundError</code> are defined here (not in the registry). <code>validate()</code> returns <code>list[str]</code> — callers raise if needed. A module-level <code>_FILE_CACHE</code> dict holds mtime-keyed loaded concepts.</div>
 
     <div class="steps-title">Implementation steps</div>
 
-    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Create <code>adapter/harness/process_concept.py</code> and define <code>ProcessConceptStep</code>.</strong> Fields: <code>id: str</code> (slug format — alphanumeric and underscores only, enforced by regex on construction), <code>description: str</code>, <code>depends_on: list[str]</code> (step IDs within the same concept), <code>risk_level: RiskLevel</code> (imported from <code>risk.py</code>), <code>abstraction_level: str</code> (must be one of <code>"leaf"</code> or <code>"subgoal"</code>), <code>expected_tools: list[str]</code> (advisory; cross-checked against <code>tool_availability_manifest</code> at init but not a run blocker), <code>success_criteria: str</code>, <code>strategy_hint: str | None = None</code> (must be a valid strategy name from the 6-strategy order in <code>recovery.py</code> if set). Implement <code>to_dict()</code> and <code>from_dict(d)</code> on the step.</div></div>
+    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Create <code>adapter/harness/process_concept.py</code> and define <code>ProcessConceptStep</code>.</strong> Fields: <code>id: str</code>, <code>description: str</code>, <code>depends_on: list[str]</code> (step IDs within the same concept), <code>risk_level: str</code> (LOW/MEDIUM/HIGH), <code>abstraction_level: str</code> (module/goal/subgoal/function/leaf/statement — mapped to int 0/1/2 at seed time), <code>expected_tools: list[str]</code>, <code>success_criteria: list[str]</code>, <code>strategy_hint: str | None = None</code>. Define <code>ProcessConceptValidationError(ValueError)</code> and <code>ProcessConceptNotFoundError(KeyError)</code>. Implement <code>to_dict()</code> and <code>from_dict(d)</code>.</div></div>
 
-    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Define <code>ProcessConcept</code> dataclass.</strong> Fields: <code>id: str</code>, <code>name: str</code>, <code>description: str</code>, <code>success_criteria: str</code> (top-level; individual steps carry their own per-step criteria), <code>schema_version: str</code> (must equal <code>"1.0"</code> — strict check; any other value raises <code>ProcessConceptValidationError</code> immediately), <code>steps: list[ProcessConceptStep]</code>. Define <code>ProcessConceptValidationError(ValueError)</code> as the typed exception raised for all structural violations.</div></div>
+    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Define <code>ProcessConcept</code> dataclass.</strong> Fields: <code>id: str</code>, <code>name: str</code>, <code>description: str</code>, <code>success_criteria: list[str]</code>, <code>schema_version: str = "1"</code>, <code>steps: list[ProcessConceptStep]</code>. Implement <code>to_dict()</code> and <code>from_dict(d)</code>. <code>from_dict()</code> constructs the object and calls <code>validate()</code> — if errors are returned, raises <code>ProcessConceptValidationError</code>.</div></div>
 
-    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Implement <code>ProcessConcept.validate()</code>.</strong> Three checks in order: (1) step ID uniqueness within the concept — duplicate IDs raise immediately; (2) <code>depends_on</code> reference validity — every ID in any step's <code>depends_on[]</code> must exist as a step ID in this concept (forward references are allowed — validation is over the complete step list, not incremental); (3) cycle detection — run a topological sort; any cycle raises <code>ProcessConceptValidationError</code> with the cycle path in the message. <code>validate()</code> is called by both <code>from_dict()</code> and <code>from_file()</code> before returning.</div></div>
+    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Implement <code>ProcessConcept.validate() → list[str]</code>.</strong> Returns a list of error strings (empty = valid). Checks: (1) non-empty concept ID; (2) step ID uniqueness; (3) <code>depends_on</code> reference validity (forward references allowed); (4) valid <code>risk_level</code> and <code>abstraction_level</code> enum values; (5) dependency cycle detection via iterative DFS. All errors are collected and returned together (not fail-fast).</div></div>
 
-    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Implement <code>ProcessConcept.from_dict(d: dict)</code>.</strong> Parses the raw JSON dict: checks <code>schema_version</code> first, constructs <code>ProcessConceptStep</code> objects from <code>d["steps"]</code>, then calls <code>validate()</code>. If any field is missing or has the wrong type, raise <code>ProcessConceptValidationError</code> with the field path in the message. Never return a partially-constructed concept. Implement a symmetric <code>to_dict()</code> for serialisation to the journal.</div></div>
+    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Implement <code>ProcessConcept.from_file(path: str | Path) → ProcessConcept</code>.</strong> Reads and JSON-parses the file. Checks mtime against <code>_FILE_CACHE</code> — returns cached object if mtime unchanged. On cache miss: parses via <code>from_dict()</code>, validates, stores in <code>_FILE_CACHE[(str(path))] = (mtime, concept)</code>. Raises <code>ProcessConceptNotFoundError</code> if the file is absent; raises <code>ProcessConceptValidationError</code> for malformed JSON or structural errors.</div></div>
 
-    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Implement <code>ProcessConcept.seed_task_graph(objective: str) → TaskGraph</code>.</strong> Converts each <code>ProcessConceptStep</code> to a <code>Task</code> (imported from <code>task_graph.py</code>). Task IDs are namespaced as <code>{concept_id}:{step_id}</code> — raw step IDs never appear in the output task graph. <code>depends_on[]</code> entries are translated to the same namespaced format. <code>risk_level</code> and <code>abstraction_level</code> are copied directly. If <code>strategy_hint</code> is set, it is written to <code>task.assigned_strategy</code>. All tasks are initialised with status <code>PENDING</code>. Returns a fully constructed <code>TaskGraph</code> that can be passed directly to <code>validate_task_graph()</code>.</div></div>
+    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Implement <code>ProcessConcept.seed_task_graph(task_graph: Any) → None</code>.</strong> Appends <code>Task</code> objects into the caller-supplied <code>TaskGraph</code> in-place. Task IDs are namespaced as <code>{concept_id}:{step_id}</code>. <code>depends_on[]</code> entries are translated to the same namespaced format. <code>abstraction_level</code> strings are mapped to int via <code>_ABSTRACTION_MAP</code>. <code>strategy_hint</code> is written to <code>task.assigned_strategy</code>. All tasks initialised as PENDING. Sets <code>task_graph.changed = True</code>.</div></div>
 
-    <div class="section-label">Acceptance tests</div>
-    <div class="test-item"><code>from_dict()</code> raises <code>ProcessConceptValidationError</code> when a step's <code>depends_on</code> references a step ID that does not exist in the concept's step list — error message includes the missing ID</div>
-    <div class="test-item"><code>validate()</code> detects a two-step cycle (step A depends on step B, step B depends on step A) and raises <code>ProcessConceptValidationError</code> with the cycle path in the message</div>
-    <div class="test-item"><code>seed_task_graph()</code> produces a <code>TaskGraph</code> where all task IDs are namespaced as <code>{concept_id}:{step_id}</code> — no raw step IDs appear; confirmed by asserting no task ID equals any step ID from the source concept</div>
-    <div class="test-item"><code>seed_task_graph()</code> output passes <code>validate_task_graph()</code> without error for a well-formed 4-step concept with a linear dependency chain</div>
+    <div class="section-label">Acceptance tests (as implemented)</div>
+    <div class="test-item">T01 · <code>ProcessConceptStep.to_dict()</code> / <code>from_dict()</code> round-trip preserves all fields including <code>strategy_hint</code></div>
+    <div class="test-item">T02 · <code>ProcessConcept.to_dict()</code> / <code>from_dict()</code> round-trip preserves all fields and all steps</div>
+    <div class="test-item">T03 · <code>validate()</code> returns <code>[]</code> for a well-formed concept with a 2-step linear chain</div>
+    <div class="test-item">T04 · <code>validate()</code> returns an error containing "Duplicate" when two steps share the same ID</div>
+    <div class="test-item">T05 · <code>validate()</code> returns an error referencing the unknown ID when a step's <code>depends_on</code> names a non-existent step</div>
+    <div class="test-item">T06 · <code>validate()</code> detects a two-step cycle (A→B, B→A) and returns an error containing "cycle"</div>
+    <div class="test-item">T07 · <code>validate()</code> returns an error referencing "risk_level" for an unknown value like "CRITICAL"</div>
+    <div class="test-item">T08 · <code>validate()</code> returns an error referencing "abstraction_level" for an unknown value like "granular"</div>
   </div>
 </div>
 
@@ -225,28 +259,32 @@ body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
   <div class="task-header" onclick="toggleTask('ppc2')">
     <span class="task-id">P-PC.2</span>
     <span class="task-name">ProcessRegistry — file-backed concept registry</span>
-    <span class="task-meta">Week 1 · ~1.5 days</span>
+    <span class="task-meta">Week 1 · ~1.5 days · <span style="color:#4ade80">✓ done</span></span>
   </div>
   <div class="task-body" id="body-ppc2">
-    <div class="desc-block">Creates <code>adapter/harness/process_registry.py</code>. The registry maps concept IDs to file paths and handles loading with file-level caching keyed by (path, mtime). A module-level default registry instance is auto-populated from the <code>concepts/</code> directory at startup. Thread-safe for concurrent <code>load()</code> calls from parallel run starts.</div>
+    <div class="desc-block">Creates <code>adapter/harness/process_registry.py</code>. The registry maps concept IDs to file paths. File-level mtime caching lives in <code>process_concept._FILE_CACHE</code>. A module-level <code>DEFAULT_REGISTRY</code> is auto-populated from <code>concepts/</code> at import time. Thread-safe for concurrent registration and listing.</div>
+
+    <div class="note-block" style="border-left-color:var(--green)"><strong style="color:var(--green)">As implemented:</strong> <code>ProcessConceptNotFoundError</code> is imported from <code>process_concept.py</code> (not defined here). <code>register()</code> stores the path string without checking file existence — the error is surfaced at <code>load()</code> time. The per-file mtime cache is a module-level dict in <code>process_concept.py</code>; <code>load()</code> simply calls <code>ProcessConcept.from_file()</code> which handles caching. <code>scan_directory()</code> does a full parse (not a fast peek) and silently skips failures. <code>DEFAULT_REGISTRY</code> path: <code>Path(__file__).parent.parent.parent / "concepts"</code>.</div>
 
     <div class="steps-title">Implementation steps</div>
 
-    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Create <code>adapter/harness/process_registry.py</code> and define <code>ProcessRegistry</code>.</strong> Internal state: <code>_registry: dict[str, Path]</code> mapping concept IDs to absolute file paths, <code>_cache: dict[tuple[Path, float], ProcessConcept]</code> keyed by (path, mtime). Define <code>ProcessConceptNotFoundError(KeyError)</code> as the typed exception for missing concept lookups. Use a <code>threading.Lock</code> to guard concurrent <code>load()</code> calls — parallel run starts may request the same concept simultaneously.</div></div>
+    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Create <code>adapter/harness/process_registry.py</code> and define <code>ProcessRegistry</code>.</strong> Internal state: <code>_registry: dict[str, str]</code> mapping concept IDs to file path strings. Use a <code>threading.Lock</code> to guard concurrent mutations. Import <code>ProcessConceptNotFoundError</code> from <code>process_concept.py</code>.</div></div>
 
-    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Implement <code>register(concept_id: str, path: str | Path)</code>.</strong> Resolves the path to absolute. Raises <code>ProcessConceptNotFoundError</code> immediately if the file does not exist at registration time — fail fast at startup, not at first use. Stores the mapping in <code>_registry</code>. Does not load the concept eagerly; loading is deferred to the first <code>load()</code> call so that startup is fast even with many registered concepts.</div></div>
+    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Implement <code>register(concept_id: str, file_path: str | Path)</code>.</strong> Stores the string path in <code>_registry</code> under the concept ID. Does not check file existence at registration time — errors surface at <code>load()</code> via <code>from_file()</code>.</div></div>
 
-    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Implement <code>load(concept_id: str) → ProcessConcept</code>.</strong> Looks up the path in <code>_registry</code>; raises <code>ProcessConceptNotFoundError</code> with the missing ID in the message if not registered. Reads the file's current mtime. If <code>(path, mtime)</code> is in <code>_cache</code>: return the cached object. Otherwise: call <code>ProcessConcept.from_file(path)</code>, store in cache, and return. The mtime key means a concept file edited between runs is automatically reloaded without restarting the adapter.</div></div>
+    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Implement <code>load(concept_id: str) → ProcessConcept</code>.</strong> Looks up the path in <code>_registry</code>; raises <code>ProcessConceptNotFoundError</code> if not registered. Delegates to <code>ProcessConcept.from_file(path)</code> which handles mtime-keyed caching transparently.</div></div>
 
-    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Implement <code>list_available() → list[str]</code>.</strong> Returns a sorted list of all registered concept IDs. Used by the canvas process_concept node to populate the concept picker dropdown. Also useful for debugging and the adapter's <code>GET /concepts</code> endpoint (if added in P-PC.5).</div></div>
+    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Implement <code>list_available() → list[str]</code>.</strong> Returns a sorted list of all registered concept IDs. Used by <code>GET /run/concepts</code> and for debugging.</div></div>
 
-    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Implement <code>scan_directory(dir_path: str | Path)</code>.</strong> Walks the directory for all <code>*.json</code> files. For each file: attempts to read its <code>id</code> field from the JSON without fully parsing (fast peek), then calls <code>register(concept_id, path)</code>. Files that fail JSON parsing or are missing the <code>id</code> field are logged as a warning and skipped — the scan never aborts due to a single malformed file. Create a module-level <code>DEFAULT_REGISTRY = ProcessRegistry()</code> and call <code>DEFAULT_REGISTRY.scan_directory("concepts/")</code> at module import time if the directory exists.</div></div>
+    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Implement <code>scan_directory(directory: str | Path) → int</code>.</strong> Globs <code>*.json</code>, skips <code>concept_schema.json</code>. For each file: calls <code>ProcessConcept.from_file()</code> — on success calls <code>register()</code>; on any exception silently continues. Returns count of successfully registered concepts. At module level: <code>DEFAULT_REGISTRY = ProcessRegistry()</code> followed by <code>DEFAULT_REGISTRY.scan_directory(Path(__file__).parent.parent.parent / "concepts")</code>.</div></div>
 
-    <div class="section-label">Acceptance tests</div>
-    <div class="test-item"><code>register()</code> raises <code>ProcessConceptNotFoundError</code> when called with a path that does not exist on disk — the error message includes the path</div>
-    <div class="test-item"><code>load()</code> on an unregistered concept_id raises <code>ProcessConceptNotFoundError</code> with the missing ID in the message; a second call with the same ID raises the same error without side effects</div>
-    <div class="test-item"><code>scan_directory()</code> registers all valid JSON files in a temp directory and logs exactly one warning (without raising) for a file with invalid JSON structure — the other valid files are still registered</div>
-    <div class="test-item"><code>list_available()</code> returns concept IDs in sorted alphabetical order; after <code>scan_directory()</code> on a directory with 3 valid concept files it returns a list of length 3</div>
+    <div class="section-label">Acceptance tests (as implemented)</div>
+    <div class="test-item">T19 · <code>register()</code> + <code>load()</code> round-trip: file written to temp dir, registered, loaded — returned concept ID matches</div>
+    <div class="test-item">T20 · <code>load()</code> on an unregistered ID raises <code>ProcessConceptNotFoundError</code></div>
+    <div class="test-item">T21 · <code>list_available()</code> returns concept IDs in sorted order after registering 3 concepts</div>
+    <div class="test-item">T22 · <code>scan_directory()</code> registers all valid concept files; skips <code>concept_schema.json</code>; returns correct count</div>
+    <div class="test-item">T23 · <code>scan_directory()</code> on a nonexistent path returns 0 without raising</div>
+    <div class="test-item">T28 · 50 concurrent <code>register()</code> calls from separate threads complete without error</div>
   </div>
 </div>
 
@@ -255,28 +293,30 @@ body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
   <div class="task-header" onclick="toggleTask('ppc3')">
     <span class="task-id">P-PC.3</span>
     <span class="task-name">Bundled concept JSON files and JSON schema</span>
-    <span class="task-meta">Week 2 · ~1.5 days</span>
+    <span class="task-meta">Week 2 · ~1.5 days · <span style="color:#4ade80">✓ done</span></span>
   </div>
   <div class="task-body" id="body-ppc3">
-    <div class="desc-block">Creates the <code>concepts/</code> directory containing a formal JSON schema (<code>concept_schema.json</code>) and four domain concept files. Each concept file is validated against the schema on load. The four concepts cover the most common AI coding agent task classes: debugging a failing test, implementing a new feature, reviewing code, and refactoring a module.</div>
+    <div class="desc-block">Creates the <code>concepts/</code> directory containing a formal JSON schema (<code>concept_schema.json</code>) and four domain concept files. Each concept file is validated on load via <code>ProcessConcept.from_file()</code>. The four concepts cover the most common AI coding agent task classes: debugging a failing test, implementing a new feature, reviewing code, and refactoring a module.</div>
+
+    <div class="note-block" style="border-left-color:var(--green)"><strong style="color:var(--green)">As implemented — actual step counts and structure:</strong> Step counts differ from the original plan: <code>debug_test_failure</code>=5, <code>implement_feature</code>=6, <code>code_review</code>=6, <code>refactor_module</code>=5. The <code>implement_feature</code> and <code>code_review</code> concepts do not use a parallel fan-out in the implemented versions — all steps are linear or sequentially chained. <code>abstraction_level</code> enum in the schema includes all six values (module/goal/subgoal/function/leaf/statement). Schema validation is via <code>ProcessConcept.validate()</code>, not the <code>jsonschema</code> library.</div>
 
     <div class="steps-title">Implementation steps</div>
 
-    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Create <code>concepts/concept_schema.json</code>.</strong> A JSON Schema (draft-07) document covering all fields of <code>ProcessConcept</code> and <code>ProcessConceptStep</code>. Top-level required fields: <code>id</code>, <code>name</code>, <code>description</code>, <code>success_criteria</code>, <code>schema_version</code>, <code>steps</code>. Per-step required fields: <code>id</code>, <code>description</code>, <code>depends_on</code>, <code>risk_level</code>, <code>abstraction_level</code>, <code>expected_tools</code>, <code>success_criteria</code>. <code>strategy_hint</code> is optional and its enum must match the 6 strategy names. <code>risk_level</code> enum: <code>"LOW"</code>, <code>"MEDIUM"</code>, <code>"HIGH"</code>. <code>abstraction_level</code> enum: <code>"leaf"</code>, <code>"subgoal"</code>. Add schema validation via <code>jsonschema</code> in <code>ProcessConcept.from_dict()</code> — validation runs before field parsing.</div></div>
+    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Create <code>concepts/concept_schema.json</code>.</strong> JSON Schema (draft-07) covering all <code>ProcessConcept</code> and <code>ProcessConceptStep</code> fields. Required per-step: <code>id</code>, <code>description</code>. Optional: <code>depends_on</code> (default []), <code>risk_level</code> (LOW/MEDIUM/HIGH), <code>abstraction_level</code> (module/goal/subgoal/function/leaf/statement), <code>expected_tools</code>, <code>success_criteria</code>, <code>strategy_hint</code> (6-value enum or null).</div></div>
 
-    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Create <code>concepts/debug_test_failure.json</code>.</strong> 6 steps: <code>read_test</code> (read the failing test, LOW) → <code>run_test</code> (capture live failure output, LOW, expected_tools: ["bash"]) → <code>locate_source</code> (trace stack to source, LOW, expected_tools: ["read_file","grep"]) → <code>form_hypothesis</code> (state root cause and predicted fix, LOW) → <code>apply_fix</code> (apply minimal change, MEDIUM, strategy_hint: "MINIMAL_FIX", expected_tools: ["edit_file"]) → <code>verify_fix</code> (re-run suite, check regressions, LOW, expected_tools: ["bash"]). Linear dependency chain.</div></div>
+    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Create <code>concepts/debug_test_failure.json</code> — 5 steps, linear chain.</strong> <code>gather_context</code> (LOW, module, BROADER_SEARCH) → <code>reproduce_failure</code> (LOW, function, TRACE_EXEC) → <code>isolate_root_cause</code> (MEDIUM, function, TRACE_EXEC) → <code>apply_fix</code> (HIGH, leaf, MINIMAL_FIX) → <code>verify_fix</code> (LOW, module, DIRECT_EDIT).</div></div>
 
-    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Create <code>concepts/implement_feature.json</code>.</strong> 7 steps: <code>read_requirements</code> (LOW) is the entry point. <code>survey_codebase</code> (LOW, expected_tools: ["grep","read_file"]) and <code>design_interface</code> (LOW, abstraction_level: "subgoal") both depend on <code>read_requirements</code> — this is the only concept with a parallel fan-out. <code>implement</code> (MEDIUM, expected_tools: ["edit_file"]) depends on both <code>survey_codebase</code> and <code>design_interface</code>. <code>write_tests</code> (LOW, expected_tools: ["edit_file"]) depends on <code>implement</code>. <code>run_tests</code> (LOW, expected_tools: ["bash"]) depends on <code>write_tests</code>. <code>refine</code> (LOW) depends on <code>run_tests</code>. This concept tests the parallel fan-out and re-join in <code>seed_task_graph()</code>.</div></div>
+    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Create <code>concepts/implement_feature.json</code> — 6 steps, linear chain.</strong> <code>clarify_requirements</code> (LOW, goal, BROADER_SEARCH) → <code>survey_codebase</code> (LOW, module) → <code>design_interface</code> (MEDIUM, subgoal) → <code>implement_core</code> (HIGH, leaf) → <code>write_tests</code> (LOW, function) → <code>run_and_verify</code> (LOW, module).</div></div>
 
-    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Create <code>concepts/code_review.json</code>.</strong> 5 steps, strictly sequential: <code>read_diff</code> (LOW, expected_tools: ["read_file","bash"]) → <code>check_logic_correctness</code> (LOW) → <code>check_test_coverage</code> (LOW) → <code>check_code_style</code> (LOW) → <code>summarise_findings</code> (LOW). No parallel steps, no strategy hints. The simplest concept — used as the baseline fixture in integration tests where minimal complexity is needed.</div></div>
+    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Create <code>concepts/code_review.json</code> — 6 steps with fan-out.</strong> <code>understand_change</code> (LOW, module) → <code>check_correctness</code> (MEDIUM, function, TRACE_EXEC) and <code>check_security</code> (HIGH, function, TRACE_EXEC) and <code>check_style_conventions</code> (LOW, leaf) all depend on <code>understand_change</code>. <code>check_test_coverage</code> (MEDIUM, function) depends on <code>check_correctness</code>. <code>summarise_findings</code> (LOW, goal) depends on all four check steps.</div></div>
 
-    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Create <code>concepts/refactor_module.json</code>.</strong> 7 steps: <code>read_current</code> (LOW, expected_tools: ["read_file"]) → <code>run_tests_baseline</code> (LOW, expected_tools: ["bash"]) → <code>identify_hotspots</code> (LOW, strategy_hint: "BROADER_SEARCH", expected_tools: ["grep","read_file"]) → <code>design_target</code> (LOW, abstraction_level: "subgoal") → <code>apply_refactor</code> (HIGH, expected_tools: ["edit_file"]) → <code>run_tests_post</code> (LOW, expected_tools: ["bash"]) → <code>verify_no_regression</code> (LOW). The <code>apply_refactor</code> step with risk_level HIGH verifies that the HIGH-risk path in the execution and verification layers is exercised when this concept seeds the task graph.</div></div>
+    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Create <code>concepts/refactor_module.json</code> — 5 steps, linear chain.</strong> <code>understand_current_behaviour</code> (LOW, module) → <code>identify_refactor_targets</code> (LOW, subgoal) → <code>plan_changes</code> (MEDIUM, subgoal) → <code>apply_refactor</code> (HIGH, leaf, MINIMAL_FIX) → <code>verify_equivalence</code> (LOW, module).</div></div>
 
-    <div class="section-label">Acceptance tests</div>
-    <div class="test-item">All 4 bundled concept files parse via <code>ProcessConcept.from_file()</code> without error and each passes <code>validate()</code> — confirmed by asserting no exception is raised and returned objects have the correct step counts (6, 7, 5, 7)</div>
-    <div class="test-item"><code>implement_feature.json</code> encodes the parallel fan-out correctly: <code>survey_codebase</code> and <code>design_interface</code> both list <code>read_requirements</code> in their <code>depends_on[]</code>; after <code>seed_task_graph()</code> the <code>implement</code> task depends on both namespaced IDs</div>
-    <div class="test-item"><code>refactor_module.json</code> produces an <code>apply_refactor</code> task with <code>risk_level=HIGH</code> after <code>seed_task_graph()</code> — confirmed by iterating the returned task graph and asserting the task with the expected namespaced ID has the HIGH risk level</div>
-    <div class="test-item">JSON schema validation (<code>concept_schema.json</code>) correctly rejects a concept file where one step has <code>"risk_level": "CRITICAL"</code> (not in the enum) — <code>ProcessConceptValidationError</code> is raised and its message references the invalid field</div>
+    <div class="section-label">Acceptance tests (as implemented)</div>
+    <div class="test-item">All 4 bundled concept files parse via <code>ProcessConcept.from_file()</code> and <code>validate()</code> returns <code>[]</code> — confirmed by the <code>test_bundled_concepts_valid</code> bonus test</div>
+    <div class="test-item">T07 · <code>validate()</code> returns an error for <code>risk_level="CRITICAL"</code></div>
+    <div class="test-item">T11 · <code>seed_task_graph()</code> maps abstraction_level strings to the correct ints (module→0, subgoal→1, leaf→2)</div>
+    <div class="test-item">T14 · <code>seed_task_graph()</code> preserves risk_level — HIGH step produces a task with <code>risk_level="HIGH"</code></div>
   </div>
 </div>
 
@@ -284,29 +324,31 @@ body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
 <div class="task-block" id="tb-ppc4">
   <div class="task-header" onclick="toggleTask('ppc4')">
     <span class="task-id">P-PC.4</span>
-    <span class="task-name">loop.py initialize() integration</span>
-    <span class="task-meta">Week 2 · ~2 days</span>
+    <span class="task-name">loop.py initialize_harness() — new initialisation function</span>
+    <span class="task-meta">Week 2 · ~2 days · <span style="color:#4ade80">✓ done</span></span>
   </div>
   <div class="task-body" id="body-ppc4">
-    <div class="desc-block">Modifies <code>adapter/harness/loop.py</code> to accept an optional <code>process_concept</code> parameter in <code>initialize()</code>. When provided, <code>seed_task_graph(objective)</code> pre-populates the task graph before the existing <code>decomposition_gate()</code> call. All existing gates, invariants, and post-init paths are unchanged. The <code>process_concept=None</code> path is structurally identical to the pre-concept code.</div>
+    <div class="desc-block">Adds <code>initialize_harness()</code> to <code>adapter/harness/loop.py</code>. No <code>initialize()</code> function existed; this is a new standalone function. When <code>process_concept</code> is provided it seeds the task graph, validates, calls <code>warm_start()</code>, then calls <code>decomposition_gate()</code>. Returns a result dict. Adds <code>process_concept_id</code> to <code>HarnessRunState</code> in <code>state_store.py</code>.</div>
+
+    <div class="note-block" style="border-left-color:var(--green)"><strong style="color:var(--green)">As implemented:</strong> Function is <code>initialize_harness(world_model, diagnostics, task_graph, process_concept=None, experience_store=None, strategy_state=None, failure_diagnostics=None, task_class="", dep_graph_budget=None) → dict</code>. Returns <code>{"valid": bool, "errors": list[str], "decomposition_gate": bool, "process_concept_id": str | None}</code>. Validation failure (from <code>validate_task_graph()</code>) returns <code>valid=False</code> immediately without calling <code>decomposition_gate()</code>. <code>decomposition_gate()</code> is imported from <code>.gates</code> (returns bool).</div>
 
     <div class="steps-title">Implementation steps</div>
 
-    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Add <code>process_concept: ProcessConcept | None = None</code> to <code>initialize()</code> in <code>loop.py</code>.</strong> Import <code>ProcessConcept</code> from <code>process_concept.py</code>. Update the function signature — no other code changes required for the <code>None</code> branch since the entire seeding block is guarded by <code>if process_concept is not None</code>. The parameter is keyword-only to prevent positional argument breakage in existing callers.</div></div>
+    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Add <code>initialize_harness()</code> to <code>loop.py</code> with optional <code>process_concept</code> parameter.</strong> Update loop.py import to include <code>decomposition_gate</code> from <code>.gates</code> (was already imported in the existing <code>run_one_iteration</code> call chain but not at the module level). The function is a new top-level addition alongside <code>run_one_iteration()</code>.</div></div>
 
-    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Insert the seeding block at the start of <code>initialize()</code>, before <code>decomposition_gate()</code>.</strong> The block: <code>if process_concept is not None: state.task_graph = process_concept.seed_task_graph(state.objective)</code>. Write the concept ID and step count to the journal: <code>log_journal(f"Seeded task_graph from concept '{process_concept.id}' ({len(process_concept.steps)} steps)")</code>. If <code>process_concept is None</code>: the <code>task_graph</code> field of <code>HarnessRunState</code> remains empty — the model will populate it via the existing <code>update_task_graph()</code> path.</div></div>
+    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Implement seeding block: if concept provided, call <code>concept.seed_task_graph(task_graph)</code>.</strong> This appends tasks in-place. The caller's task_graph object is mutated; no new graph is created.</div></div>
 
-    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Confirm the existing gate sequence is unchanged for both branches.</strong> After the seeding block (or its absence), the code continues to <code>validate_task_graph()</code> and then <code>decomposition_gate()</code> exactly as before. Do not add a conditional skip of these gates for the concept-seeded branch — the gates are not bypassed. A concept that seeds a task graph misaligned with the objective is caught and handled by the existing gate logic. Document this with a comment.</div></div>
+    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Call <code>validate_task_graph(task_graph)</code>. If errors: return <code>{"valid": False, "errors": errors, "decomposition_gate": False, "process_concept_id": ...}</code>.</strong> Same validation gate as model-driven runs — not bypassed for concept-seeded graphs (INV-PC-02).</div></div>
 
-    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Confirm <code>warm_start(experience_store)</code> is called after the seeding block.</strong> It already is in the existing initialization sequence. Add a comment at the call site: <code># warm_start enriches strategy_state.prior_strategy_weights; called after seed_task_graph() so experience priors layer on top of the concept structure</code>. Assert in the test suite that warm_start does not replace the seeded task_graph (see acceptance tests below).</div></div>
+    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Call <code>warm_start()</code> when <code>experience_store</code> is provided.</strong> Called after seeding so that experience priors layer on top of the concept structure. Uses same call signature as in <code>run_one_iteration()</code>.</div></div>
 
-    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Add <code>process_concept_id: str | None</code> to <code>HarnessRunState</code> in <code>state_store.py</code>.</strong> This field carries the concept ID for observability — it is written at initialization and visible in the journal and harness-state API response. It is not the <code>ProcessConcept</code> object itself (which is not serialised to the state store). Update <code>to_dict()</code> and <code>from_dict()</code>. Export from <code>adapter/harness/__init__.py</code>.</div></div>
+    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Add <code>process_concept_id: str | None = None</code> to <code>HarnessRunState</code> in <code>state_store.py</code>.</strong> Update <code>to_dict()</code> (adds <code>"process_concept_id": self.process_concept_id</code>) and <code>from_dict()</code> (adds <code>process_concept_id=d.get("process_concept_id")</code>). Export from <code>adapter/harness/__init__.py</code>. Also export <code>initialize_harness</code>.</div></div>
 
-    <div class="section-label">Acceptance tests</div>
-    <div class="test-item">When <code>process_concept=None</code>: <code>initialize()</code> produces a <code>HarnessRunState</code> with an empty task_graph (no tasks) — structurally identical to all P0–P9 run initializations (regression guard)</div>
-    <div class="test-item">When a valid <code>ProcessConcept</code> with 6 steps is provided: the returned <code>HarnessRunState.task_graph</code> contains exactly 6 tasks, all with status PENDING, and <code>state.process_concept_id</code> equals the concept's ID</div>
-    <div class="test-item"><code>decomposition_gate()</code> is called after seeding and is not bypassed — confirmed by a fixture that provides a concept whose steps are misaligned with the objective; asserting the gate returns GATHER_CLARIFICATION (not PROCEED)</div>
-    <div class="test-item"><code>warm_start()</code> is called after seeding and its return value updates <code>strategy_state.prior_strategy_weights</code> without replacing or clearing the seeded task_graph — task count remains 6 after warm_start completes</div>
+    <div class="section-label">Acceptance tests (as implemented)</div>
+    <div class="test-item">T15 · <code>initialize_harness()</code> with a concept calls <code>decomposition_gate()</code> — result dict has <code>decomposition_gate</code> key with bool value</div>
+    <div class="test-item">T16 · <code>initialize_harness(process_concept=None)</code> returns <code>valid=True</code>, <code>process_concept_id=None</code> — structurally unchanged (INV-PC-03)</div>
+    <div class="test-item">T17 · <code>initialize_harness()</code> returns <code>process_concept_id</code> matching the concept's ID</div>
+    <div class="test-item">T18 · When <code>task_graph</code> has an orphaned dependency, <code>initialize_harness()</code> returns <code>valid=False</code> with non-empty <code>errors</code></div>
   </div>
 </div>
 
@@ -315,28 +357,30 @@ body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
   <div class="task-header" onclick="toggleTask('ppc5')">
     <span class="task-id">P-PC.5</span>
     <span class="task-name">FlowSpec harness_meta extension and run-start wiring</span>
-    <span class="task-meta">Week 3 · ~1.5 days</span>
+    <span class="task-meta">Week 3 · ~1.5 days · <span style="color:#4ade80">✓ done</span></span>
   </div>
   <div class="task-body" id="body-ppc5">
-    <div class="desc-block">Extends the FlowSpec <code>harness_meta</code> block with an optional <code>process_concept_id</code> field. Updates <code>adapter/validate.py</code> and wires <code>adapter/run_api.py</code> to load the named concept from the registry at run start and pass it to <code>initialize()</code>. Establishes the clear error semantics: absent field → unchanged behaviour; present and found → seeded run; present and not found → hard configuration error.</div>
+    <div class="desc-block">Extends the FlowSpec <code>harness_meta</code> block with an optional <code>process_concept_id</code> field. Updates <code>adapter/validate.py</code> and wires <code>adapter/run_api.py</code> to load the named concept from the registry at run start. Establishes the clear error semantics: absent field → unchanged behaviour; present and found → seeded run; present and not found → hard 400 error (INV-PC-04).</div>
+
+    <div class="note-block" style="border-left-color:var(--green)"><strong style="color:var(--green)">As implemented:</strong> <code>GET /run/concepts</code> (not <code>GET /concepts</code>) returns <code>{"concepts": ["id1","id2",…]}</code> — a list of IDs only, not full summaries with step_count. The <code>DEFAULT_REGISTRY</code> and <code>ProcessConceptNotFoundError</code> are imported from the harness package via a <code>try/except ImportError</code> guard so <code>run_api.py</code> stays importable even if harness is unavailable. <code>validate.py</code> also validates the <code>process_concept</code> harness node's <code>harness_config.concept_id</code> field (non-empty string if present) and adds <code>"process_concept"</code> to <code>_HARNESS_NODE_TYPES</code>.</div>
 
     <div class="steps-title">Implementation steps</div>
 
-    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Add <code>process_concept_id: z.string().optional()</code> to the <code>harness_meta</code> shape in <code>spec/schema.ts</code>.</strong> The field is optional — existing flows that omit it parse without error and behave identically to before. Regenerate <code>spec/schema.json</code>. No migration script is needed since the field is optional and all existing flows are forward-compatible.</div></div>
+    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Add <code>process_concept_id: z.string().optional()</code> to <code>HarnessMeta</code> in <code>spec/schema.ts</code>.</strong> Optional — existing flows parse unchanged. No migration needed.</div></div>
 
-    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Update <code>adapter/validate.py</code> to accept <code>process_concept_id</code> in <code>harness_meta</code>.</strong> Validation rule: if the field is present, it must be a non-empty string (reject empty string with a clear message). The adapter does not validate that the ID exists in the registry at flow-validation time — concept availability is a runtime concern, not a spec-validity concern. A valid spec with a missing concept fails at run start, not at validation time.</div></div>
+    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Update <code>adapter/validate.py</code>.</strong> Add <code>"process_concept"</code> to <code>_HARNESS_NODE_TYPES</code>. In <code>_validate_harness_configs()</code>: add <code>elif ntype == "process_concept"</code> case validating <code>concept_id</code> is a non-empty string. After the node loop: check <code>harness_meta.process_concept_id</code> — if present and not a non-empty string, raise 400.</div></div>
 
-    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Add a module-level <code>DEFAULT_REGISTRY</code> to <code>adapter/run_api.py</code>.</strong> At module import: instantiate <code>ProcessRegistry()</code> and call <code>scan_directory(Path("concepts/"))</code> if the directory exists. Log the number of concepts found at INFO level. If the directory is absent: log at DEBUG and continue — the registry is empty, which is valid (it just means no concepts are available).</div></div>
+    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Add <code>DEFAULT_REGISTRY</code> import at the top of <code>adapter/run_api.py</code>.</strong> Wrapped in <code>try/except ImportError</code>: <code>from harness.process_registry import DEFAULT_REGISTRY as _concept_registry</code> and <code>from harness.process_concept import ProcessConceptNotFoundError as _ProcessConceptNotFoundError</code>. If import fails: set both to <code>None</code>. The <code>concepts/</code> directory scan happens inside <code>process_registry.py</code> at import time.</div></div>
 
-    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Wire the run-start concept load in <code>run_api.py</code>'s harness run handler.</strong> After loading the flow spec: if <code>harness_meta.process_concept_id</code> is set, call <code>DEFAULT_REGISTRY.load(concept_id)</code>. If <code>ProcessConceptNotFoundError</code> is raised: return a 400 response with the message <code>"process_concept_id '{id}' not found in registry — check that the concept file exists in the concepts/ directory"</code>. Do not fall back to <code>None</code>. Pass the loaded concept to <code>initialize()</code>. If the field is absent: pass <code>process_concept=None</code>.</div></div>
+    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Wire the run-start concept validation in the POST /run handler.</strong> After <code>_validate_spec(spec)</code>: read <code>harness_meta.process_concept_id</code>. If set and <code>_concept_registry</code> is not None: call <code>_concept_registry.load(pc_id)</code>. If <code>_ProcessConceptNotFoundError</code> is raised: return 400 with message referencing the missing ID and directing to <code>GET /run/concepts</code> (INV-PC-04).</div></div>
 
-    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Add <code>GET /concepts</code> endpoint to <code>run_api.py</code>.</strong> Returns a JSON list of available concept summaries: <code>[{"id": "...", "name": "...", "description": "...", "step_count": N}]</code> for each registered concept. Used by the canvas node's concept picker dropdown to enumerate available options without requiring a full concept load. Response is sorted by concept ID. Returns an empty array if no concepts are registered — not a 404.</div></div>
+    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Add <code>GET /run/concepts</code> endpoint.</strong> Returns <code>{"concepts": _concept_registry.list_available()}</code> — a sorted list of registered concept IDs. Returns <code>{"concepts": []}</code> if registry is unavailable. Not a 404 on empty list.</div></div>
 
-    <div class="section-label">Acceptance tests</div>
-    <div class="test-item">A flow spec with <code>harness_meta.process_concept_id = "debug_test_failure"</code> passes <code>adapter/validate.py</code> without error; a spec with <code>process_concept_id = ""</code> (empty string) fails validation with a message containing "non-empty"</div>
-    <div class="test-item">Run start with a valid concept ID loads the concept from the registry and passes it to <code>initialize()</code> — confirmed by asserting <code>HarnessRunState.process_concept_id</code> equals the requested ID and <code>task_graph</code> contains the concept's step count</div>
-    <div class="test-item">Run start with <code>process_concept_id = "nonexistent_concept"</code> returns a 400 response containing the missing ID and the words "not found in registry" — it does not start a run with an empty task_graph</div>
-    <div class="test-item"><code>GET /concepts</code> returns all 4 bundled concepts after <code>scan_directory("concepts/")</code> runs at startup; each entry has the correct <code>step_count</code> matching the number of steps in the corresponding JSON file</div>
+    <div class="section-label">Acceptance tests (as implemented)</div>
+    <div class="test-item">validate.py accepts <code>harness_meta.process_concept_id = "debug_test_failure"</code>; rejects <code>process_concept_id = ""</code> with "non-empty" in the message</div>
+    <div class="test-item">Run start with an unknown <code>process_concept_id</code> raises <code>ProcessConceptNotFoundError</code> caught by the handler → 400 response (INV-PC-04)</div>
+    <div class="test-item"><code>GET /run/concepts</code> returns <code>{"concepts": ["code_review","debug_test_failure","implement_feature","refactor_module"]}</code> after startup</div>
+    <div class="test-item"><code>compile_process_concept_node({"concept_id":"debug_test_failure",...})</code> emits code that sets <code>harness_meta.process_concept_id = "debug_test_failure"</code></div>
   </div>
 </div>
 
@@ -345,28 +389,29 @@ body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
   <div class="task-header" onclick="toggleTask('ppc6')">
     <span class="task-id">P-PC.6</span>
     <span class="task-name">Canvas process_concept node type</span>
-    <span class="task-meta">Week 3 · ~2 days</span>
+    <span class="task-meta">Week 3 · ~2 days · <span style="color:#fbbf24">⚡ partial — backend only</span></span>
   </div>
   <div class="task-body" id="body-ppc6">
-    <div class="desc-block">Adds the <code>process_concept</code> canvas node type. Lets flow authors pick a concept from the registry, preview its ordered steps with risk badges and dependency arrows, and observe live task status per step during an active run. The canvas node writes the <code>process_concept_id</code> into <code>harness_meta</code> — it does not generate standalone adapter calls.</div>
+    <div class="desc-block">Adds the <code>process_concept</code> canvas node type. Lets flow authors pick a concept from the registry, preview its steps, and observe live task status per step during an active run.</div>
+
+    <div class="note-block" style="border-left-color:var(--amber)"><strong style="color:var(--amber)">Partially implemented — backend only:</strong> The backend compiler (<code>compile_process_concept_node()</code> in <code>node_compilers.py</code>) and the validator (<code>"process_concept"</code> added to <code>_HARNESS_NODE_TYPES</code>, <code>concept_id</code> config validation in <code>validate.py</code>) are complete. The React canvas component (<code>ProcessConceptNode.tsx</code>), the canvas node type registration (<code>packages/canvas/nodeTypes.ts</code>), the concept picker, and the live run overlay were deferred to P11.</div>
 
     <div class="steps-title">Implementation steps</div>
 
-    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Add <code>ProcessConceptNodeConfig</code> shape to <code>spec/schema.ts</code>.</strong> Fields: <code>concept_id: string</code> (required when the node is present in a flow), <code>show_steps: boolean</code> (default <code>true</code>), <code>show_step_dependencies: boolean</code> (default <code>true</code>), <code>max_steps_shown: number</code> (default 20). Regenerate <code>spec/schema.json</code> and update <code>adapter/validate.py</code> to validate the config shape.</div></div>
+    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Add <code>compile_process_concept_node(node: dict, harness_meta_var: str) → str</code> to <code>adapter/harness/node_compilers.py</code>.</strong> Emits Python code that sets <code>harness_meta.process_concept_id = concept_id</code> (attribute path for dataclass, dict path for dict). Generates no standalone adapter function call. Add <code>"process_concept": compile_process_concept_node</code> to <code>HARNESS_NODE_COMPILERS</code>.</div></div>
 
-    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Create <code>src/components/nodes/harness/ProcessConceptNode.tsx</code>.</strong> Node header: concept name (fetched from <code>GET /concepts</code> on mount) and concept ID in the phase accent colour. Node body (when <code>show_steps=true</code>): an ordered list of step rows, each showing step sequence number, description (truncated to 80 chars), risk_level badge (LOW=slate, MEDIUM=amber, HIGH=red), and — when set — a <code>strategy_hint</code> chip in a muted accent colour. A step count chip in the header shows the total number of steps.</div></div>
+    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Add <code>"process_concept"</code> to <code>_HARNESS_NODE_TYPES</code> in <code>adapter/validate.py</code>.</strong> Add case in <code>_validate_harness_configs()</code> validating that <code>harness_config.concept_id</code> is a non-empty string when present. Validate <code>harness_meta.process_concept_id</code> after the node loop.</div></div>
 
-    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Implement the concept picker.</strong> In the node's config panel: a dropdown populated by <code>GET /concepts</code> showing concept name and step count for each available concept. Selecting a concept updates <code>node_config.concept_id</code> and re-renders the step list. If the concepts endpoint is unavailable (adapter not running): show a "Registry unavailable — enter concept ID manually" fallback with a text input. The node never blocks flow authoring due to registry connectivity.</div></div>
+    <div class="step"><span class="step-num">3 (deferred)</span><div class="step-body" style="color:var(--t1);opacity:.6"><strong>Create <code>src/components/nodes/harness/ProcessConceptNode.tsx</code>.</strong> Deferred to P11 — frontend canvas component, concept picker, step list with risk badges and dependency arrows.</div></div>
 
-    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Implement the step dependency visualization.</strong> When <code>show_step_dependencies=true</code>: draw SVG connector lines between step rows that have <code>depends_on</code> relationships — entry-point steps (no <code>depends_on</code>) are left-aligned; dependent steps are slightly indented. For the <code>implement_feature</code> concept: both <code>survey_codebase</code> and <code>design_interface</code> draw connector lines from <code>read_requirements</code>, and <code>implement</code> draws lines from both — this visually communicates the fan-out/re-join structure.</div></div>
+    <div class="step"><span class="step-num">4 (deferred)</span><div class="step-body" style="color:var(--t1);opacity:.6"><strong>Register <code>"process_concept"</code> in <code>packages/canvas/nodeTypes.ts</code>.</strong> Deferred to P11.</div></div>
 
-    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Implement the live run overlay and register the node type.</strong> During an active harness run: poll <code>GET /runs/{run_id}/harness-state</code> at the same 2-second interval as other harness nodes. Cross-reference each step's namespaced task ID against the live task_graph state. Overlay the task status badge (PENDING/ACTIVE/VERIFYING/COMPLETE/FAILED/BLOCKED) on the step row. Register <code>"process_concept"</code> in <code>packages/canvas/nodeTypes.ts</code>. Add <code>compile_process_concept_node(node_config)</code> to <code>adapter/harness/node_compilers.py</code> — it emits <code>node_config.concept_id</code> into the flow's <code>harness_meta.process_concept_id</code> field and generates no standalone adapter calls. Export from <code>adapter/harness/__init__.py</code>.</div></div>
+    <div class="step"><span class="step-num">5 (deferred)</span><div class="step-body" style="color:var(--t1);opacity:.6"><strong>Live run overlay — poll harness-state and cross-reference step IDs.</strong> Deferred to P11.</div></div>
 
-    <div class="section-label">Acceptance tests</div>
-    <div class="test-item">Step rows render with correct risk_level badge colours from a <code>refactor_module</code> fixture: LOW steps show slate badges, MEDIUM would show amber (none in this concept), HIGH (<code>apply_refactor</code>) shows a red badge</div>
-    <div class="test-item">Dependency arrows render between the correct step rows for the <code>implement_feature</code> concept: <code>survey_codebase</code> and <code>design_interface</code> both show a connector line from <code>read_requirements</code>; <code>implement</code> shows connector lines from both of them</div>
-    <div class="test-item">Live run overlay: steps whose namespaced task IDs are COMPLETE in the fixture show a green COMPLETE badge; steps that are PENDING show no status overlay — confirmed from a mixed-status fixture with 3 COMPLETE and 3 PENDING tasks</div>
-    <div class="test-item"><code>compile_process_concept_node({"concept_id": "debug_test_failure", ...})</code> produces output that sets <code>harness_meta.process_concept_id = "debug_test_failure"</code> in the compiled FlowSpec; it does not emit any standalone adapter function call</div>
+    <div class="section-label">Acceptance tests (as implemented — backend compiler only)</div>
+    <div class="test-item"><code>compile_process_concept_node({"harness_config": {"concept_id": "debug_test_failure"}}, "meta")</code> emits code setting <code>meta.process_concept_id = "debug_test_failure"</code></div>
+    <div class="test-item">A spec with a <code>process_concept</code> node and <code>concept_id = ""</code> in <code>harness_config</code> fails <code>validate.py</code> with a message referencing "non-empty"</div>
+    <div class="test-item">Canvas UI tests (risk badges, dependency arrows, live overlay) — deferred to P11</div>
   </div>
 </div>
 
@@ -375,28 +420,37 @@ body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
   <div class="task-header" onclick="toggleTask('ppc7')">
     <span class="task-id">P-PC.7</span>
     <span class="task-name">Integration tests and cross-component wiring verification</span>
-    <span class="task-meta">Week 4 · ~2 days</span>
+    <span class="task-meta">Week 4 · ~2 days · <span style="color:#4ade80">✓ done</span></span>
   </div>
   <div class="task-body" id="body-ppc7">
-    <div class="desc-block">Creates <code>adapter/tests/test_harness_process_concepts.py</code> with end-to-end integration tests, invariant tests, and regression guards. Uses the in-memory session fixture from P8 — no Postgres required. Runs the full P0–P9 test suite to confirm no regressions from the <code>loop.py</code> and <code>state_store.py</code> changes.</div>
+    <div class="desc-block">Creates <code>adapter/tests/test_harness_process_concepts.py</code> with 28 named tests (T01–T28) plus two bonus tests covering the full feature surface. Tests are infrastructure-free — no Postgres, no live adapter required. The test file is organised by feature: round-trip serialisation (T01–T02), <code>validate()</code> error detection (T03–T08), <code>seed_task_graph()</code> mechanics (T09–T14), <code>initialize_harness()</code> integration (T15–T18), <code>ProcessRegistry</code> operations (T19–T23), <code>from_file()</code> caching + thread safety (T24–T28), and two bonus tests validating all bundled concept files and the DEFAULT_REGISTRY auto-scan.</div>
+
+    <div class="section-label">As implemented — divergences from the plan</div>
+    <div class="desc-block" style="border-left:3px solid var(--amber);padding-left:.75rem">
+      <strong>Test file organisation:</strong> Tests are organised by feature layer (serialisation → validation → seeding → initialisation → registry → caching), not by task (P-PC.1–P-PC.7). This makes test failures easier to locate.<br><br>
+      <strong>No full-path integration tests using loop iterations:</strong> Integration tests stop at <code>initialize_harness()</code> (T15–T18). The harness core uses Python 3.12 PEP 695 syntax (<code>def fn[F: ...]</code>) which cannot be imported under Python 3.11 in the CI container; full-loop iteration tests are deferred.<br><br>
+      <strong>Two bonus tests added beyond T28:</strong> <code>test_bundled_concepts_valid</code> (loads all 4 concept files and asserts <code>validate()</code> returns <code>[]</code>) and <code>test_default_registry_populated</code> (asserts all 4 bundled concept IDs appear in <code>DEFAULT_REGISTRY</code> after auto-scan).
+    </div>
 
     <div class="steps-title">Implementation steps</div>
 
-    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Write four end-to-end path tests.</strong> Each test exercises the full path: concept JSON file → <code>ProcessRegistry.load()</code> → <code>initialize(process_concept=concept)</code> → one loop iteration → assert task graph state. Use <code>debug_test_failure</code> and <code>implement_feature</code> as the test fixtures. Confirm that the seeded task graph's first leaf task (no <code>depends_on</code>) is selected by <code>select_unblocked_leaf()</code> and becomes ACTIVE. Use the in-memory session fixture from P8 — no live adapter or Postgres required.</div></div>
+    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Write serialisation round-trips (T01–T02).</strong> T01: <code>ProcessConceptStep.to_dict()</code>/<code>from_dict()</code> preserves all 8 fields. T02: <code>ProcessConcept.to_dict()</code>/<code>from_dict()</code> preserves concept ID, name, schema_version, and step list.</div></div>
 
-    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Write INV-PC-01 test: concept is a prior, not a constraint.</strong> Seed the task graph from <code>code_review</code> (5 steps). Run <code>initialize()</code>. Then force a verification failure on the first task, triggering <code>diagnose_and_replan()</code>. Assert that replanning successfully adds a new task not present in the original concept — <code>task_graph.tasks</code> length exceeds 5 after replan. The concept's step IDs remain in the graph but the graph is no longer limited to them.</div></div>
+    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Write validate() error tests (T03–T08).</strong> T03: valid concept returns <code>[]</code>. T04: duplicate step IDs reported with the duplicate ID in the message. T05: <code>depends_on</code> referencing a non-existent step reported with the missing ID. T06: two-step cycle detected (A→B, B→A). T07: invalid <code>risk_level</code> value reported. T08: invalid <code>abstraction_level</code> value reported.</div></div>
 
-    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Write INV-PC-03 test: process_concept=None leaves harness structurally unchanged.</strong> Call <code>initialize(process_concept=None)</code>. Assert the returned <code>HarnessRunState</code> has an empty <code>task_graph</code> (zero tasks). Assert that <code>HarnessRunState.process_concept_id</code> is <code>None</code>. Assert that all fields present in a standard P0-era harness state are present and have their expected default values — no new required fields, no structural changes to the None-path run.</div></div>
+    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Write seed_task_graph() tests (T09–T14).</strong> T09: task IDs namespaced as <code>{concept_id}:{step_id}</code>. T10: <code>depends_on</code> references also namespaced. T11: <code>abstraction_level</code> strings mapped to ints (module/goal→0, subgoal/function→1, leaf/statement→2). T12: <code>task_graph.changed</code> is <code>True</code> after seeding. T13: seeded graph passes <code>validate_task_graph()</code> with no errors (INV-PC-02). T14: <code>risk_level</code> preserved from concept steps.</div></div>
 
-    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Write schema round-trip tests for all 4 bundled concepts.</strong> For each concept: load via <code>from_file()</code>, call <code>seed_task_graph("placeholder objective")</code>, validate the resulting <code>TaskGraph</code> via <code>validate_task_graph()</code>. Assert that every step's <code>risk_level</code>, <code>depends_on[]</code> (namespaced), and <code>strategy_hint</code> (when set) are correctly reflected in the corresponding <code>Task</code> objects. No information loss permitted.</div></div>
+    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Write initialize_harness() tests (T15–T18).</strong> T15: <code>decomposition_gate</code> key present in returned dict after seeded init. T16: <code>process_concept=None</code> produces <code>process_concept_id=None</code> and <code>valid=True</code> (INV-PC-03). T17: concept ID appears in the returned dict. T18: orphaned dependency task causes <code>valid=False</code> and non-empty <code>errors</code> list.</div></div>
 
-    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Run the full P0–P9 regression suite and confirm 208/208 pass.</strong> Execute <code>pytest adapter/tests/ -v -k harness</code>. All existing tests must pass — the parameter addition to <code>initialize()</code> and the new optional field on <code>HarnessRunState</code> must not break any existing test. Fix any regression before marking this task complete. Record the final passing count in a summary comment at the top of <code>test_harness_process_concepts.py</code>.</div></div>
+    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Write ProcessRegistry tests (T19–T23).</strong> T19: <code>register()</code>/<code>load()</code> round-trip. T20: <code>load()</code> raises <code>ProcessConceptNotFoundError</code> for unknown IDs. T21: <code>list_available()</code> returns sorted alphabetical list. T22: <code>scan_directory()</code> registers all concept files and skips <code>concept_schema.json</code>. T23: <code>scan_directory()</code> on absent path returns 0.</div></div>
+
+    <div class="step"><span class="step-num">6</span><div class="step-body"><strong>Write from_file() caching and thread safety tests (T24–T28).</strong> T24: mtime-keyed cache returns same object on repeated calls. T25: cache is invalidated when file mtime changes. T26: missing file raises <code>ProcessConceptNotFoundError</code>. T27: invalid JSON raises <code>ProcessConceptValidationError</code>. T28: 50 concurrent <code>register()</code> calls complete without error (threading.Lock).</div></div>
 
     <div class="section-label">Acceptance tests</div>
-    <div class="test-item">Full path integration: <code>scan_directory("concepts/") → load("debug_test_failure") → initialize(process_concept=concept)</code> produces a <code>HarnessRunState</code> with 6 tasks, all PENDING, with namespaced IDs of the form <code>"debug_test_failure:{step_id}"</code></div>
-    <div class="test-item">INV-PC-01: a replanning call during a <code>code_review</code>-seeded run successfully adds a task not defined in the original concept; <code>len(task_graph.tasks) > 5</code> after the replan — the concept did not prevent the graph from growing</div>
-    <div class="test-item">INV-PC-03: <code>initialize(process_concept=None)</code> produces a <code>HarnessRunState</code> with zero tasks in <code>task_graph</code> and <code>process_concept_id=None</code> — structurally identical to all pre-concept P0–P9 test fixtures</div>
-    <div class="test-item">208/208 P0–P9 acceptance tests pass after all process concepts changes land — confirmed by running <code>pytest adapter/tests/ -v -k harness</code> and asserting exit code 0</div>
+    <div class="test-item">T13: seeded <code>TaskGraph</code> with 2 tasks passes <code>validate_task_graph()</code> with no errors — INV-PC-02 verified for the in-memory path</div>
+    <div class="test-item">T16: <code>initialize_harness(process_concept=None)</code> returns <code>process_concept_id=None</code> and <code>valid=True</code> — INV-PC-03 verified for the None path</div>
+    <div class="test-item"><code>test_bundled_concepts_valid</code>: all 4 bundled concept files pass <code>validate()</code> — concept schema integrity confirmed on every test run</div>
+    <div class="test-item"><code>test_default_registry_populated</code>: <code>DEFAULT_REGISTRY</code> contains all 4 bundled concept IDs after module import — auto-scan at startup confirmed</div>
   </div>
 </div>
 
@@ -412,34 +466,34 @@ body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
   <div class="file-map">
 <span class="f-dir">adapter/harness/</span>
   process_concept.py                    <span class="f-new">NEW</span>  <span class="f-note">ProcessConceptStep · ProcessConcept · ProcessConceptValidationError · from_dict · from_file · seed_task_graph · to_dict · validate</span>
-  process_registry.py                   <span class="f-new">NEW</span>  <span class="f-note">ProcessRegistry · ProcessConceptNotFoundError · register · load · list_available · scan_directory · DEFAULT_REGISTRY module instance</span>
-  __init__.py                           <span class="f-mod">MOD</span>  <span class="f-note">export ProcessConcept · ProcessConceptStep · ProcessConceptValidationError · ProcessRegistry · ProcessConceptNotFoundError · DEFAULT_REGISTRY</span>
-  loop.py                               <span class="f-mod">MOD</span>  <span class="f-note">add process_concept keyword parameter to initialize() · seeding block before decomposition_gate() · journal log entry on seed · warm_start comment</span>
+  process_registry.py                   <span class="f-new">NEW</span>  <span class="f-note">ProcessRegistry · register · load · list_available · scan_directory · DEFAULT_REGISTRY module instance (ProcessConceptNotFoundError lives in process_concept.py)</span>
+  __init__.py                           <span class="f-mod">MOD</span>  <span class="f-note">export ProcessConcept · ProcessConceptStep · ProcessConceptValidationError · ProcessConceptNotFoundError · ProcessRegistry · DEFAULT_REGISTRY · initialize_harness</span>
+  loop.py                               <span class="f-mod">MOD</span>  <span class="f-note">add initialize_harness() function (new, alongside run_one_iteration) · seeds task graph, runs validate_task_graph, calls decomposition_gate · returns dict with valid/errors/decomposition_gate/process_concept_id</span>
   state_store.py                        <span class="f-mod">MOD</span>  <span class="f-note">add process_concept_id: str | None field to HarnessRunState · update to_dict/from_dict</span>
   node_compilers.py                     <span class="f-mod">MOD</span>  <span class="f-note">add compile_process_concept_node — emits concept_id into harness_meta, no standalone adapter calls</span>
 
 <span class="f-dir">concepts/</span>  <span class="f-new">NEW DIR</span>
   concept_schema.json                   <span class="f-new">NEW</span>  <span class="f-note">JSON Schema draft-07 covering ProcessConcept + ProcessConceptStep; all concept files validated against this on load</span>
-  debug_test_failure.json               <span class="f-new">NEW</span>  <span class="f-note">6 steps: read_test → run_test → locate_source → form_hypothesis → apply_fix (MINIMAL_FIX hint) → verify_fix</span>
-  implement_feature.json                <span class="f-new">NEW</span>  <span class="f-note">7 steps: parallel fan-out (survey_codebase + design_interface both from read_requirements) re-joining at implement</span>
-  code_review.json                      <span class="f-new">NEW</span>  <span class="f-note">5 steps: read_diff → check_logic_correctness → check_test_coverage → check_code_style → summarise_findings (linear)</span>
-  refactor_module.json                  <span class="f-new">NEW</span>  <span class="f-note">7 steps: includes apply_refactor (risk_level: HIGH) and identify_hotspots (strategy_hint: BROADER_SEARCH)</span>
+  debug_test_failure.json               <span class="f-new">NEW</span>  <span class="f-note">5 steps: gather_context → reproduce_failure → isolate_root_cause → apply_fix (HIGH risk, MINIMAL_FIX hint) → verify_fix</span>
+  implement_feature.json                <span class="f-new">NEW</span>  <span class="f-note">6 steps: clarify_requirements → survey_codebase → design_interface → implement_core (HIGH risk) → write_tests → run_and_verify</span>
+  code_review.json                      <span class="f-new">NEW</span>  <span class="f-note">6 steps: understand_change → check_correctness → check_security (HIGH risk) → check_style_conventions → check_test_coverage → summarise_findings</span>
+  refactor_module.json                  <span class="f-new">NEW</span>  <span class="f-note">5 steps: understand_current_behaviour → identify_refactor_targets → plan_changes → apply_refactor (HIGH risk, MINIMAL_FIX hint) → verify_equivalence</span>
 
 <span class="f-dir">spec/</span>
   schema.ts                             <span class="f-mod">MOD</span>  <span class="f-note">add process_concept_id: z.string().optional() to harness_meta block · add ProcessConceptNodeConfig shape</span>
   schema.json                           <span class="f-mod">MOD</span>  <span class="f-note">regenerated from schema.ts</span>
 
-<span class="f-dir">src/components/nodes/harness/</span>
-  ProcessConceptNode.tsx                <span class="f-new">NEW</span>  <span class="f-note">concept picker · ordered step list · risk badges · strategy_hint chips · dependency arrows · live run overlay</span>
-  index.tsx                             <span class="f-mod">MOD</span>  <span class="f-note">export ProcessConceptNode alongside existing harness node components</span>
+<span class="f-dir">src/components/nodes/harness/</span>  <span style="color:var(--amber);font-size:11px">⚡ DEFERRED — backend only in this phase (P11 canvas work)</span>
+  ProcessConceptNode.tsx                <span style="color:var(--t2);font-size:11px">NOT CREATED</span>  <span class="f-note">concept picker · ordered step list · risk badges · strategy_hint chips · dependency arrows · live run overlay — deferred to P11</span>
+  index.tsx                             <span style="color:var(--t2);font-size:11px">NOT MODIFIED</span>  <span class="f-note">deferred to P11</span>
 
-<span class="f-dir">packages/canvas/</span>
-  nodeTypes.ts                          <span class="f-mod">MOD</span>  <span class="f-note">register "process_concept" node type with ProcessConceptNode component and default config</span>
-  nodeDefaults.ts                       <span class="f-mod">MOD</span>  <span class="f-note">default ProcessConceptNodeConfig values (show_steps: true, show_step_dependencies: true, max_steps_shown: 20)</span>
+<span class="f-dir">packages/canvas/</span>  <span style="color:var(--amber);font-size:11px">⚡ DEFERRED — deferred to P11</span>
+  nodeTypes.ts                          <span style="color:var(--t2);font-size:11px">NOT MODIFIED</span>  <span class="f-note">register "process_concept" node type — deferred to P11</span>
+  nodeDefaults.ts                       <span style="color:var(--t2);font-size:11px">NOT MODIFIED</span>  <span class="f-note">default ProcessConceptNodeConfig values — deferred to P11</span>
 
 <span class="f-dir">adapter/</span>
   validate.py                           <span class="f-mod">MOD</span>  <span class="f-note">accept process_concept_id in harness_meta (non-empty string if present) · add ProcessConceptNodeConfig shape validation</span>
-  run_api.py                            <span class="f-mod">MOD</span>  <span class="f-note">DEFAULT_REGISTRY module instance · scan_directory at startup · concept load at run start · 400 on missing concept · GET /concepts endpoint</span>
+  run_api.py                            <span class="f-mod">MOD</span>  <span class="f-note">try/except import guard for registry · concept existence check at run start (400 on missing) · GET /run/concepts endpoint returning IDs only · imports guarded to avoid breakage when harness unavailable</span>
 
 <span class="f-dir">adapter/tests/</span>
   test_harness_process_concepts.py      <span class="f-new">NEW</span>  <span class="f-note">all 28 acceptance tests (T01–T28) · in-memory session fixture (no Postgres) · INV-PC-01 + INV-PC-03 invariant tests · P0–P9 regression guard</span>
@@ -448,7 +502,7 @@ body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
 
 <div class="card">
   <div class="card-title">Files NOT touched in this phase</div>
-  <div class="card-body">All existing harness logic modules are untouched except for <code>loop.py</code> (parameter addition) and <code>state_store.py</code> (one optional field). In particular, the following are unchanged:
+  <div class="card-body">All existing harness logic modules are untouched except for <code>loop.py</code> (new <code>initialize_harness()</code> function added — existing <code>run_one_iteration()</code> and <code>select_best_action()</code> are unchanged) and <code>state_store.py</code> (one optional <code>process_concept_id</code> field added). Frontend canvas files are deferred to P11 and were not modified. In particular, the following are unchanged:
   <code style="font-family:var(--font-mono);font-size:11px;background:var(--bg2);padding:1px 5px;border-radius:3px">world_model.py</code>
   <code style="font-family:var(--font-mono);font-size:11px;background:var(--bg2);padding:1px 5px;border-radius:3px">task_graph.py</code>
   <code style="font-family:var(--font-mono);font-size:11px;background:var(--bg2);padding:1px 5px;border-radius:3px">control_state.py</code>
@@ -475,8 +529,8 @@ body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
 <tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.1 — ProcessConcept dataclasses</td><td><em style="color:var(--t1)">none</em></td><td style="font-size:11.5px;color:var(--t1)">Foundation — all other tasks import from <code>process_concept.py</code></td></tr>
 <tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.2 — ProcessRegistry</td><td><span class="dep-tag">P-PC.1</span></td><td style="font-size:11.5px;color:var(--t1)">Registry calls <code>ProcessConcept.from_file()</code> — requires the dataclass to be stable</td></tr>
 <tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.3 — Bundled concept files</td><td><span class="dep-tag">P-PC.1</span></td><td style="font-size:11.5px;color:var(--t1)">Files are validated by <code>from_file()</code> on load; the dataclass schema must be final before writing the files</td></tr>
-<tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.4 — loop.py integration</td><td><span class="dep-tag">P-PC.1</span><span class="dep-tag">P-PC.2</span></td><td style="font-size:11.5px;color:var(--t1)"><code>initialize()</code> imports <code>ProcessConcept</code> (P-PC.1) and the registry is used by the run-start path (P-PC.2)</td></tr>
-<tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.5 — Schema + run_api.py wiring</td><td><span class="dep-tag">P-PC.2</span><span class="dep-tag">P-PC.4</span></td><td style="font-size:11.5px;color:var(--t1)"><code>run_api.py</code> calls <code>registry.load()</code> (P-PC.2) and passes the result to <code>initialize()</code> (P-PC.4)</td></tr>
+<tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.4 — loop.py integration</td><td><span class="dep-tag">P-PC.1</span><span class="dep-tag">P-PC.2</span></td><td style="font-size:11.5px;color:var(--t1)"><code>initialize_harness()</code> imports <code>ProcessConcept</code> (P-PC.1) and the registry is used by the run-start path (P-PC.2)</td></tr>
+<tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.5 — Schema + run_api.py wiring</td><td><span class="dep-tag">P-PC.2</span><span class="dep-tag">P-PC.4</span></td><td style="font-size:11.5px;color:var(--t1)"><code>run_api.py</code> calls <code>registry.load()</code> (P-PC.2) for existence check; <code>initialize_harness()</code> (P-PC.4) is called by the run handler with the loaded concept</td></tr>
 <tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.6 — Canvas node</td><td><span class="dep-tag">P-PC.5</span></td><td style="font-size:11.5px;color:var(--t1)"><code>ProcessConceptNodeConfig</code> is defined in the schema step (P-PC.5.1); <code>GET /concepts</code> endpoint (P-PC.5.5) must exist for the picker</td></tr>
 <tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.7 — Integration tests</td><td><span class="dep-tag">P-PC.1</span><span class="dep-tag">P-PC.2</span><span class="dep-tag">P-PC.3</span><span class="dep-tag">P-PC.4</span><span class="dep-tag">P-PC.5</span></td><td style="font-size:11.5px;color:var(--t1)">End-to-end tests exercise the full path across all prior tasks; P-PC.6 canvas tests are frontend-only and not required for the backend integration tests</td></tr>
 </tbody>
@@ -520,7 +574,7 @@ body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
   </div>
   <div class="inv-item">
     <strong>INV-PC-03 — process_concept=None path is structurally unchanged <span class="inv-tag">P-PC.4 · P-PC.7 scope</span></strong>
-    When <code>initialize()</code> is called without a <code>process_concept</code> (or with <code>process_concept=None</code>), the resulting <code>HarnessRunState</code> must be structurally identical to a state produced by the pre-concept code. No new required fields, no changed defaults, no altered task graph initialization. The optional <code>process_concept_id</code> field on <code>HarnessRunState</code> is <code>None</code> and does not affect any downstream logic. This ensures that all 208 P0–P9 tests continue to pass without modification. Verified by P-PC.7.3 and P-PC.7.5.
+    When <code>initialize_harness()</code> is called without a <code>process_concept</code> (or with <code>process_concept=None</code>), the function returns <code>{"valid": True, "errors": [], "decomposition_gate": ..., "process_concept_id": None}</code>. No tasks are seeded. The optional <code>process_concept_id</code> field on <code>HarnessRunState</code> is <code>None</code> and does not affect any downstream logic. Verified by T16 (<code>test_t16_initialize_harness_no_concept</code>).
   </div>
   <div class="inv-item">
     <strong>INV-PC-04 — explicitly-specified missing concept is a hard error <span class="inv-tag">P-PC.5 scope</span></strong>
@@ -544,58 +598,60 @@ body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
 <div id="tests" class="tab-content">
 
 <div class="card">
-  <div class="card-title">All 28 acceptance tests — <code>adapter/tests/test_harness_process_concepts.py</code></div>
-  <div class="card-body">All tests use in-memory fixtures — no live database or running adapter required. Run with <code>pytest adapter/tests/test_harness_process_concepts.py -v</code>. Run the full regression suite with <code>pytest adapter/tests/ -v -k harness</code> to confirm 208/208 P0–P9 tests still pass.</div>
+  <div class="card-title">All 28 acceptance tests + 2 bonus — <code>adapter/tests/test_harness_process_concepts.py</code></div>
+  <div class="card-body">All tests use in-memory fixtures — no live database or running adapter required. Run with <code>pytest adapter/tests/test_harness_process_concepts.py -v</code>. Tests are organised by feature layer rather than by task, making regressions easier to locate. Two bonus tests validate all bundled concept files and the DEFAULT_REGISTRY auto-scan.</div>
 </div>
 
-<div class="section-label">P-PC.1 — ProcessConcept dataclasses (4 tests)</div>
-<div class="test-item">T01 · <code>from_dict()</code> raises <code>ProcessConceptValidationError</code> when a step's <code>depends_on</code> references a non-existent step ID — error message includes the missing ID</div>
-<div class="test-item">T02 · <code>validate()</code> detects a two-step cycle (A→B, B→A) and raises <code>ProcessConceptValidationError</code> with the cycle path in the message</div>
-<div class="test-item">T03 · <code>seed_task_graph()</code> namespaces all task IDs as <code>{concept_id}:{step_id}</code> — no task ID equals any raw step ID from the source concept</div>
-<div class="test-item">T04 · <code>seed_task_graph()</code> output passes <code>validate_task_graph()</code> without error for a well-formed 4-step linear concept</div>
+<div class="section-label">Serialisation round-trips (T01–T02)</div>
+<div class="test-item">T01 · <code>test_t01_step_roundtrip</code> — <code>ProcessConceptStep.to_dict()</code>/<code>from_dict()</code> preserves all 8 fields including optional <code>strategy_hint</code></div>
+<div class="test-item">T02 · <code>test_t02_concept_roundtrip</code> — <code>ProcessConcept.to_dict()</code>/<code>from_dict()</code> preserves concept ID, name, schema_version, and full step list</div>
 
-<div class="section-label">P-PC.2 — ProcessRegistry (4 tests)</div>
-<div class="test-item">T05 · <code>register()</code> raises <code>ProcessConceptNotFoundError</code> with the path in the message when the file does not exist on disk</div>
-<div class="test-item">T06 · <code>load()</code> on an unregistered concept_id raises <code>ProcessConceptNotFoundError</code> with the missing ID; a second call raises the same error without side effects</div>
-<div class="test-item">T07 · <code>scan_directory()</code> registers all valid JSON files in a temp directory and logs exactly one warning (without raising) for a malformed file — the other valid files are still registered</div>
-<div class="test-item">T08 · <code>list_available()</code> returns concept IDs in sorted alphabetical order; length equals the number of valid concept files registered</div>
+<div class="section-label">validate() error detection (T03–T08)</div>
+<div class="test-item">T03 · <code>test_t03_validate_valid_concept</code> — <code>validate()</code> returns <code>[]</code> for a well-formed 2-step concept</div>
+<div class="test-item">T04 · <code>test_t04_validate_duplicate_step_ids</code> — duplicate step IDs reported; error message contains "Duplicate" and the offending ID</div>
+<div class="test-item">T05 · <code>test_t05_validate_unknown_depends_on</code> — <code>depends_on</code> reference to non-existent step ID reported; error message contains the missing ID</div>
+<div class="test-item">T06 · <code>test_t06_validate_cycle_detected</code> — two-step cycle (A→B, B→A) detected; error message contains "cycle"</div>
+<div class="test-item">T07 · <code>test_t07_validate_invalid_risk_level</code> — <code>risk_level: "CRITICAL"</code> reported; error message references "risk_level"</div>
+<div class="test-item">T08 · <code>test_t08_validate_invalid_abstraction_level</code> — <code>abstraction_level: "granular"</code> reported; error message references "abstraction_level"</div>
 
-<div class="section-label">P-PC.3 — Bundled concept files (4 tests)</div>
-<div class="test-item">T09 · All 4 bundled concept files parse via <code>from_file()</code> without error; step counts are 6, 7, 5, 7 for debug_test_failure, implement_feature, code_review, refactor_module respectively</div>
-<div class="test-item">T10 · <code>implement_feature.json</code> encodes the parallel fan-out: <code>survey_codebase</code> and <code>design_interface</code> both depend on <code>read_requirements</code>; after <code>seed_task_graph()</code> the <code>implement</code> task depends on both namespaced IDs</div>
-<div class="test-item">T11 · <code>refactor_module.json</code> produces an <code>apply_refactor</code> task with <code>risk_level=HIGH</code> after <code>seed_task_graph()</code></div>
-<div class="test-item">T12 · JSON schema validation correctly rejects a concept file with <code>"risk_level": "CRITICAL"</code> — <code>ProcessConceptValidationError</code> is raised and its message references the invalid field value</div>
+<div class="section-label">seed_task_graph() mechanics (T09–T14)</div>
+<div class="test-item">T09 · <code>test_t09_seed_task_graph_namespaced_ids</code> — task IDs are <code>{concept_id}:{step_id}</code>; no raw step ID appears in the task graph</div>
+<div class="test-item">T10 · <code>test_t10_seed_task_graph_namespaced_deps</code> — <code>depends_on</code> references are also namespaced; step_b task has <code>"my_concept:step_a"</code> in its <code>depends_on</code></div>
+<div class="test-item">T11 · <code>test_t11_seed_task_graph_abstraction_mapping</code> — <code>abstraction_level</code> strings mapped to ints: module/goal→0, subgoal/function→1, leaf/statement→2</div>
+<div class="test-item">T12 · <code>test_t12_seed_task_graph_changed_flag</code> — <code>task_graph.changed</code> is <code>True</code> after <code>seed_task_graph()</code>; was <code>False</code> before</div>
+<div class="test-item">T13 · <code>test_t13_seeded_graph_passes_validate</code> — seeded <code>TaskGraph</code> passes <code>validate_task_graph()</code> with no errors (INV-PC-02)</div>
+<div class="test-item">T14 · <code>test_t14_seed_task_graph_risk_level_preserved</code> — HIGH and LOW <code>risk_level</code> values are preserved on the resulting <code>Task</code> objects</div>
 
-<div class="section-label">P-PC.4 — loop.py initialize() integration (4 tests)</div>
-<div class="test-item">T13 · <code>initialize(process_concept=None)</code> produces a <code>HarnessRunState</code> with zero tasks in <code>task_graph</code> — identical in structure to all P0–P9 run initializations</div>
-<div class="test-item">T14 · <code>initialize()</code> with a 6-step concept produces a <code>HarnessRunState</code> with exactly 6 PENDING tasks and <code>process_concept_id</code> set to the concept's ID</div>
-<div class="test-item">T15 · <code>decomposition_gate()</code> is not bypassed: providing a concept whose steps are misaligned with the objective causes the gate to return GATHER_CLARIFICATION</div>
-<div class="test-item">T16 · <code>warm_start()</code> runs after seeding and updates <code>strategy_state.prior_strategy_weights</code> without clearing the seeded task_graph — task count remains 6 after warm_start completes</div>
+<div class="section-label">initialize_harness() integration (T15–T18)</div>
+<div class="test-item">T15 · <code>test_t15_initialize_harness_calls_decomposition_gate</code> — returned dict contains <code>decomposition_gate</code> bool key; <code>valid=True</code> for a well-formed seeded graph</div>
+<div class="test-item">T16 · <code>test_t16_initialize_harness_no_concept</code> — <code>process_concept=None</code> produces <code>process_concept_id=None</code> and <code>valid=True</code> (INV-PC-03 verified)</div>
+<div class="test-item">T17 · <code>test_t17_initialize_harness_concept_id_in_result</code> — concept ID appears as <code>result["process_concept_id"]</code> after seeded init</div>
+<div class="test-item">T18 · <code>test_t18_initialize_harness_validation_failure</code> — orphaned dependency task causes <code>valid=False</code> and non-empty <code>errors</code> list in returned dict</div>
 
-<div class="section-label">P-PC.5 — FlowSpec extension + run-start wiring (4 tests)</div>
-<div class="test-item">T17 · A flow spec with <code>harness_meta.process_concept_id = "debug_test_failure"</code> passes validate.py; a spec with <code>process_concept_id = ""</code> (empty string) fails with a message containing "non-empty"</div>
-<div class="test-item">T18 · Run start with a valid concept ID results in a <code>HarnessRunState</code> with <code>process_concept_id</code> set and <code>task_graph</code> containing the concept's step count</div>
-<div class="test-item">T19 · Run start with <code>process_concept_id = "nonexistent_concept"</code> returns a 400 response containing the missing ID and the phrase "not found in registry" — no run is started</div>
-<div class="test-item">T20 · <code>GET /concepts</code> returns all 4 bundled concepts after startup; each entry has the correct <code>step_count</code> matching the concept JSON file</div>
+<div class="section-label">ProcessRegistry operations (T19–T23)</div>
+<div class="test-item">T19 · <code>test_t19_registry_register_load</code> — <code>register()</code>/<code>load()</code> round-trip returns a <code>ProcessConcept</code> with the correct ID</div>
+<div class="test-item">T20 · <code>test_t20_registry_load_not_found</code> — <code>load()</code> raises <code>ProcessConceptNotFoundError</code> for an ID that was never registered</div>
+<div class="test-item">T21 · <code>test_t21_registry_list_available</code> — <code>list_available()</code> returns alphabetically sorted IDs; set matches exactly what was registered</div>
+<div class="test-item">T22 · <code>test_t22_registry_scan_directory</code> — <code>scan_directory()</code> registers 2 valid concept files and skips <code>concept_schema.json</code>; returns count 2</div>
+<div class="test-item">T23 · <code>test_t23_registry_scan_absent_directory</code> — <code>scan_directory()</code> on a non-existent path returns 0 without raising</div>
 
-<div class="section-label">P-PC.6 — Canvas process_concept node (4 tests)</div>
-<div class="test-item">T21 · Step rows in the <code>refactor_module</code> fixture render with correct risk badges: LOW steps show slate badges; the <code>apply_refactor</code> step shows a red HIGH badge</div>
-<div class="test-item">T22 · Dependency arrows render correctly for <code>implement_feature</code>: <code>survey_codebase</code> and <code>design_interface</code> both show a connector line from <code>read_requirements</code>; <code>implement</code> shows connector lines from both</div>
-<div class="test-item">T23 · Live run overlay: steps whose namespaced task IDs are COMPLETE show a green badge; PENDING steps show no status overlay — confirmed from a mixed-status fixture with 3 COMPLETE and 4 PENDING tasks</div>
-<div class="test-item">T24 · <code>compile_process_concept_node({"concept_id": "debug_test_failure", ...})</code> sets <code>harness_meta.process_concept_id = "debug_test_failure"</code> in the compiled FlowSpec and emits no standalone adapter function calls</div>
+<div class="section-label">from_file() caching + thread safety (T24–T28)</div>
+<div class="test-item">T24 · <code>test_t24_from_file_mtime_cache</code> — repeated <code>from_file()</code> calls with unchanged mtime return the same object (identity check)</div>
+<div class="test-item">T25 · <code>test_t25_from_file_cache_invalidated_on_mtime</code> — cache is invalidated when file mtime changes; second call returns a new object with updated content</div>
+<div class="test-item">T26 · <code>test_t26_from_file_missing_raises</code> — missing file raises <code>ProcessConceptNotFoundError</code></div>
+<div class="test-item">T27 · <code>test_t27_from_file_invalid_json_raises</code> — invalid JSON raises <code>ProcessConceptValidationError</code></div>
+<div class="test-item">T28 · <code>test_t28_registry_thread_safety</code> — 50 concurrent <code>register()</code> calls complete without error; all 50 IDs appear in <code>list_available()</code></div>
 
-<div class="section-label">P-PC.7 — Integration tests (4 tests)</div>
-<div class="test-item">T25 · Full path: <code>scan_directory() → load("debug_test_failure") → initialize(process_concept=concept)</code> produces a <code>HarnessRunState</code> with 6 PENDING tasks, all with IDs of the form <code>"debug_test_failure:{step_id}"</code></div>
-<div class="test-item">T26 · INV-PC-01: a replanning call during a <code>code_review</code>-seeded run adds a task not in the original concept; <code>len(task_graph.tasks) > 5</code> after the replan</div>
-<div class="test-item">T27 · INV-PC-03: <code>initialize(process_concept=None)</code> produces a <code>HarnessRunState</code> with zero tasks and <code>process_concept_id=None</code> — structurally identical to all pre-concept P0–P9 test fixtures</div>
-<div class="test-item">T28 · 208/208 P0–P9 acceptance tests pass after all process concepts changes land — <code>pytest adapter/tests/ -v -k harness</code> exits with code 0</div>
+<div class="section-label">Bonus tests (beyond T28)</div>
+<div class="test-item"><code>test_bundled_concepts_valid</code> — all 4 bundled concept files load via <code>from_file()</code> and <code>validate()</code> returns <code>[]</code>; asserts at least 4 files were found</div>
+<div class="test-item"><code>test_default_registry_populated</code> — <code>DEFAULT_REGISTRY</code> contains all 4 bundled concept IDs after module import (debug_test_failure, implement_feature, code_review, refactor_module)</div>
 
 <div class="card" style="margin-top:.75rem">
   <div class="card-title">Running process concepts tests</div>
   <div class="card-body">
     Process concepts tests only: <code style="font-family:var(--font-mono);font-size:11.5px;background:var(--bg2);padding:3px 8px;border-radius:4px;display:inline-block">pytest adapter/tests/test_harness_process_concepts.py -v</code><br><br>
     Full harness suite (P0–P9 regression check): <code style="font-family:var(--font-mono);font-size:11.5px;background:var(--bg2);padding:3px 8px;border-radius:4px;display:inline-block">pytest adapter/tests/ -v -k harness</code><br><br>
-    No database infrastructure is required for any test in this phase — all tests use in-memory sessions or mock fixtures from the P8 test infrastructure. Canvas component tests run via the existing canvas test runner. Target: 28 + 208 = 236 total harness tests passing before this phase closes.
+    No database infrastructure is required for any test in this phase — all tests use in-memory fixtures; no Postgres, no live adapter. Canvas component tests are deferred to P11. The test file contains 30 tests total: 28 named tests (T01–T28) plus <code>test_bundled_concepts_valid</code> and <code>test_default_registry_populated</code>.
   </div>
 </div>
 

--- a/plan/phase_process_concepts_plan.html
+++ b/plan/phase_process_concepts_plan.html
@@ -1,0 +1,623 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+<title>Its Harness — Process Concepts Phase</title>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Syne:wght@400;500;600;700&display=swap');
+*{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg0:#0f1117;--bg1:#161b27;--bg2:#1e2535;
+  --t0:#e2e8f0;--t1:#94a3b8;
+  --bd0:rgba(255,255,255,0.07);--bd1:rgba(255,255,255,0.14);
+  --accent:#22d3ee;
+  --r-md:6px;--r-lg:10px;
+  --font-mono:'IBM Plex Mono',monospace;--font-ui:'Syne',sans-serif;
+  --ppc:#22d3ee;
+  --green:#4ade80;--amber:#fbbf24;--red:#f87171;--purple:#8b5cf6;--cyan:#67e8f9;--blue:#60a5fa;--slate:#94a3b8;--pink:#fb7185;
+}
+body{background:var(--bg0);font-family:var(--font-ui);color:var(--t0)}
+.root{padding:1.5rem 0;max-width:1240px;margin:0 auto}
+.hero{text-align:center;margin-bottom:1.75rem;padding:0 1rem}
+.hero h1{font-size:22px;font-weight:700;color:var(--t0);margin-bottom:.35rem;letter-spacing:-.02em}
+.hero p{font-size:13px;color:var(--t1);max-width:820px;margin:0 auto .6rem;line-height:1.6}
+.badge{display:inline-block;padding:2px 11px;border-radius:20px;font-size:11px;font-weight:600;margin-right:5px}
+.badge-blue{background:rgba(96,165,250,0.08);color:#60a5fa;border:.5px solid rgba(96,165,250,0.25)}
+.badge-green{background:rgba(74,222,128,0.08);color:#4ade80;border:.5px solid rgba(74,222,128,0.25)}
+.badge-amber{background:rgba(251,191,36,0.08);color:#fbbf24;border:.5px solid rgba(251,191,36,0.25)}
+.tabs{display:flex;gap:6px;margin-bottom:1.25rem;flex-wrap:wrap;padding:0 1rem}
+.tab{background:none;border:.5px solid var(--bd0);border-radius:var(--r-md);padding:.35rem .85rem;font-size:12px;font-family:var(--font-ui);font-weight:500;color:var(--t1);cursor:pointer;transition:all .15s}
+.tab:hover{border-color:var(--bd1);color:var(--t0)}
+.tab.active{background:rgba(34,211,238,0.07);border-color:rgba(34,211,238,0.4);color:#22d3ee;font-weight:600}
+.tab-content{display:none;padding:0 1rem}
+.tab-content.active{display:block}
+.card{background:var(--bg1);border:.5px solid var(--bd0);border-radius:var(--r-lg);padding:.9rem 1.1rem;margin-bottom:.75rem}
+.card-title{font-size:14px;font-weight:600;color:var(--t0);margin-bottom:.5rem}
+.card-body{font-size:13px;color:var(--t1);line-height:1.7}
+.summary-row{display:grid;grid-template-columns:repeat(5,1fr);gap:10px;margin-bottom:1.2rem}
+.sum-card{background:var(--bg1);border:.5px solid var(--bd0);border-radius:var(--r-lg);padding:.75rem .9rem;text-align:center}
+.sum-n{font-size:26px;font-weight:700;line-height:1}
+.sum-l{font-size:11px;color:var(--t1);margin-top:4px}
+.week-row{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-bottom:1.2rem}
+.week-card{background:var(--bg1);border:.5px solid var(--bd0);border-radius:var(--r-lg);padding:.75rem .9rem}
+.week-label{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--t1);margin-bottom:.4rem;font-family:var(--font-mono)}
+.week-title{font-size:13px;font-weight:600;color:var(--ppc);margin-bottom:.4rem}
+.week-item{font-size:11.5px;color:var(--t1);padding:.15rem 0 .15rem .8rem;position:relative;line-height:1.4}
+.week-item::before{content:'·';position:absolute;left:0;color:var(--ppc)}
+.task-block{background:var(--bg1);border:.5px solid var(--bd0);border-left:3px solid var(--ppc);border-radius:var(--r-lg);margin-bottom:1rem;overflow:hidden}
+.task-header{padding:.7rem .9rem;cursor:pointer;display:flex;align-items:baseline;gap:.6rem;transition:background .15s}
+.task-header:hover{background:var(--bg2)}
+.task-id{font-family:var(--font-mono);font-size:10px;color:var(--t1);flex-shrink:0}
+.task-name{font-size:13px;font-weight:600;color:var(--t0);flex:1}
+.task-meta{font-size:11px;color:var(--t1);flex-shrink:0}
+.task-body{padding:0 .9rem;max-height:0;overflow:hidden;transition:max-height .3s ease,padding .3s ease}
+.task-body.open{max-height:4000px;padding:.2rem .9rem .9rem}
+.steps-title{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.1em;color:var(--t1);margin-bottom:.4rem;margin-top:.7rem}
+.step{background:var(--bg2);border:.5px solid var(--bd0);border-radius:var(--r-md);padding:.55rem .8rem;margin-bottom:4px;display:flex;gap:.6rem;align-items:baseline}
+.step-num{font-family:var(--font-mono);font-size:10px;color:var(--ppc);flex-shrink:0;width:22px}
+.step-body{font-size:12px;color:var(--t1);line-height:1.5;flex:1}
+.step-body code{font-family:var(--font-mono);font-size:10.5px;background:var(--bg0);padding:1px 5px;border-radius:3px;color:#94a3b8}
+.step-body strong{color:var(--t0)}
+.test-item{font-size:11px;color:var(--green);padding:.2rem .5rem .2rem 1.1rem;position:relative;line-height:1.5}
+.test-item::before{content:'▸';position:absolute;left:0;color:var(--green);font-size:10px}
+.file-map{background:var(--bg2);border:.5px solid var(--bd0);border-radius:var(--r-md);padding:.7rem .9rem;font-family:var(--font-mono);font-size:11px;line-height:1.9;color:var(--t1)}
+.f-new{color:var(--green)}
+.f-mod{color:var(--amber)}
+.f-dir{color:var(--ppc);font-weight:600}
+.f-note{color:var(--t1);opacity:.6;font-size:10px}
+.dep-table{width:100%;border-collapse:collapse;margin-bottom:1rem}
+.dep-table th,.dep-table td{padding:.5rem .75rem;text-align:left;border-bottom:.5px solid var(--bd0);font-size:12px}
+.dep-table th{background:var(--bg2);font-weight:600;font-size:10px;text-transform:uppercase;letter-spacing:.06em;color:var(--t1)}
+.dep-tag{display:inline-block;padding:1px 7px;border-radius:3px;font-size:10px;font-family:var(--font-mono);background:var(--bg0);border:.5px solid var(--bd1);color:var(--t1);margin-right:3px}
+.inv-list{display:flex;flex-direction:column;gap:6px}
+.inv-item{background:var(--bg1);border:.5px solid var(--bd0);border-radius:var(--r-md);padding:.6rem .85rem;font-size:12px;color:var(--t1);line-height:1.5}
+.inv-item strong{color:var(--t0);display:block;margin-bottom:3px;font-size:12px}
+.inv-tag{display:inline-block;padding:1px 6px;border-radius:3px;font-size:10px;font-family:var(--font-mono);background:rgba(34,211,238,0.06);border:.5px solid rgba(34,211,238,0.2);color:var(--ppc);margin-left:6px;vertical-align:middle}
+.section-label{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.1em;color:var(--t1);margin-top:.85rem;margin-bottom:.35rem}
+.desc-block{font-size:12.5px;color:var(--t1);line-height:1.7;margin-bottom:.6rem}
+.note-block{background:var(--bg2);border:.5px solid var(--bd0);border-left:2px solid var(--amber);border-radius:var(--r-md);padding:.55rem .8rem;font-size:12px;color:var(--t1);line-height:1.5;margin-bottom:.5rem}
+.note-block strong{color:var(--amber)}
+.next-card{background:var(--bg1);border:.5px solid var(--bd0);border-radius:var(--r-lg);padding:.75rem .9rem;display:flex;align-items:center;gap:.8rem;margin-bottom:6px}
+.next-badge{font-family:var(--font-mono);font-size:11px;background:rgba(34,211,238,0.07);border:.5px solid rgba(34,211,238,0.2);color:var(--ppc);padding:2px 8px;border-radius:3px;flex-shrink:0}
+.next-body{font-size:12.5px;color:var(--t1);line-height:1.5}
+.next-body strong{color:var(--t0)}
+</style>
+</head>
+<body>
+<div class="root">
+
+<div class="hero">
+  <h1>Process Concepts Phase — Static Step Templates for Harness Runs</h1>
+  <p>Introduces process concepts: human-authored, domain-specific task graph templates that seed the harness task graph at run initialisation. A concept is a static JSON file that defines an ordered sequence of typed steps, their dependencies, expected tools, per-step success criteria, and optional strategy hints. The harness uses it as a strong prior on decomposition — the model can still adapt, add, or remove tasks during execution via the existing replanning machinery.</p>
+  <span class="badge badge-blue">4 Weeks</span>
+  <span class="badge badge-green">7 Tasks</span>
+  <span class="badge badge-amber">35 Steps</span>
+  <span class="badge badge-blue">28 Acceptance Tests</span>
+  <span class="badge" style="background:rgba(34,211,238,0.08);color:#22d3ee;border:.5px solid rgba(34,211,238,0.25)">4 Bundled Concepts</span>
+  <div style="margin-top:.6rem;font-size:12px;color:var(--t1)">Depends on: <span style="color:#fb7185">P10 Canvas complete</span> · Inserts before: <span style="color:#a3e635">P11 E2E Integration &amp; Testing</span></div>
+</div>
+
+<div class="tabs">
+  <button class="tab active" onclick="showTab('overview',this)">Overview</button>
+  <button class="tab" onclick="showTab('tasks',this)">Tasks &amp; Steps</button>
+  <button class="tab" onclick="showTab('files',this)">File Map</button>
+  <button class="tab" onclick="showTab('deps',this)">Dependencies</button>
+  <button class="tab" onclick="showTab('invariants',this)">Invariants</button>
+  <button class="tab" onclick="showTab('tests',this)">All Tests</button>
+</div>
+
+<!-- OVERVIEW -->
+<div id="overview" class="tab-content active">
+
+<div class="summary-row">
+  <div class="sum-card"><div class="sum-n" style="color:var(--ppc)">7</div><div class="sum-l">Tasks</div></div>
+  <div class="sum-card"><div class="sum-n" style="color:var(--green)">35</div><div class="sum-l">Impl. steps</div></div>
+  <div class="sum-card"><div class="sum-n" style="color:var(--green)">28</div><div class="sum-l">Acceptance tests</div></div>
+  <div class="sum-card"><div class="sum-n" style="color:var(--ppc)">4</div><div class="sum-l">Bundled concepts</div></div>
+  <div class="sum-card"><div class="sum-n" style="color:var(--ppc)">4</div><div class="sum-l">Weeks</div></div>
+</div>
+
+<div class="card">
+  <div class="card-title">What this phase delivers</div>
+  <div class="card-body">
+    Phases 0–10 gave the harness a complete reasoning and control architecture plus a full canvas UI. Every harness run currently starts from a blank task graph — the model decomposes the objective from scratch each time, guided by its world model and hypothesis set.<br><br>
+    Process concepts change the starting conditions. A concept is a hand-authored JSON file that describes a canonical, domain-tested sequence of steps for a well-known class of task. Loading a concept at run initialisation pre-populates the task graph with typed, ordered tasks before the model begins work. The model does not have to discover the decomposition — it inherits a proven scaffold and can focus its reasoning budget on the actual work rather than the meta-problem of how to structure it.<br><br>
+    <strong style="color:var(--t0)">Core layer (P-PC.1, P-PC.2, P-PC.3)</strong> — The <code>ProcessConcept</code> and <code>ProcessConceptStep</code> dataclasses define the concept data model. The <code>ProcessRegistry</code> maps concept IDs to file paths and handles loading with file-level caching. Four bundled concept files — debug_test_failure, implement_feature, code_review, and refactor_module — are shipped with the harness and auto-registered at startup via <code>scan_directory("concepts/")</code>.<br><br>
+    <strong style="color:var(--t0)">Integration layer (P-PC.4, P-PC.5)</strong> — The harness <code>initialize()</code> function in <code>loop.py</code> gains an optional <code>process_concept</code> parameter. When provided, <code>seed_task_graph(objective)</code> pre-populates the task graph before <code>decomposition_gate()</code> runs — the gate still validates alignment with the objective and can escalate if it finds a mismatch. The FlowSpec <code>harness_meta</code> block gains an optional <code>process_concept_id</code> field; <code>run_api.py</code> loads the named concept from the registry at run start and passes it to <code>initialize()</code>.<br><br>
+    <strong style="color:var(--t0)">Canvas layer (P-PC.6)</strong> — A new <code>process_concept</code> canvas node type lets flow authors pick a concept from the registry, preview its steps and dependencies, and observe concept progress (each step showing its live task status) during an active run.<br><br>
+    <strong style="color:var(--t0)">Integration tests (P-PC.7)</strong> — End-to-end tests validate the full path from concept file to seeded run. Critical invariant tests confirm that the seeded task graph remains mutable (replanning adds tasks beyond the concept's steps) and that the <code>process_concept=None</code> path is structurally identical to all pre-concept runs — no regressions.
+  </div>
+</div>
+
+<div class="week-row">
+  <div class="week-card">
+    <div class="week-label">Week 1</div>
+    <div class="week-title">Core Data Model</div>
+    <div class="week-item">P-PC.1 — ProcessConcept dataclasses + seed_task_graph()</div>
+    <div class="week-item">P-PC.2 — ProcessRegistry + scan_directory()</div>
+  </div>
+  <div class="week-card">
+    <div class="week-label">Week 2</div>
+    <div class="week-title">Concept Files &amp; Loop Integration</div>
+    <div class="week-item">P-PC.3 — 4 bundled concept JSON files + schema</div>
+    <div class="week-item">P-PC.4 — loop.py initialize() integration</div>
+  </div>
+  <div class="week-card">
+    <div class="week-label">Week 3</div>
+    <div class="week-title">Schema &amp; Canvas</div>
+    <div class="week-item">P-PC.5 — FlowSpec harness_meta extension + run-start wiring</div>
+    <div class="week-item">P-PC.6 — Canvas process_concept node type</div>
+  </div>
+  <div class="week-card">
+    <div class="week-label">Week 4</div>
+    <div class="week-title">Integration &amp; Verification</div>
+    <div class="week-item">P-PC.7 — End-to-end integration tests</div>
+    <div class="week-item">Full P0–P10 regression suite</div>
+    <div class="week-item">Cross-component wiring verification</div>
+  </div>
+</div>
+
+<div class="card" style="margin-bottom:.75rem">
+  <div class="card-title">Key design decisions</div>
+  <div class="note-block"><strong>Concepts are strong priors, not constraints:</strong> <code>seed_task_graph()</code> pre-populates the task graph but does not lock it. The existing replanning machinery (<code>diagnose_and_replan()</code>, <code>rebuild_task_graph()</code>) can add, remove, or modify tasks freely during the run. A concept is advice about how to decompose a class of task — it is not a script the model must follow exactly.</div>
+  <div class="note-block"><strong>decomposition_gate() is not bypassed:</strong> After seeding, the full <code>decomposition_gate()</code> validation runs against the seeded graph. If the concept's step structure is misaligned with the objective, the gate returns GATHER_CLARIFICATION or ESCALATE rather than silently proceeding. An invalid concept does not produce a silently wrong run.</div>
+  <div class="note-block"><strong>experience_store and process_concept are additive, not conflicting:</strong> <code>warm_start(experience_store)</code> is called after the concept seeds the task graph. It enriches <code>strategy_state.prior_strategy_weights</code> and loads successful recovery sequences, but it does not replace the seeded task structure. The concept provides the structural scaffold; experience_store provides the calibrated priors on top.</div>
+  <div class="note-block"><strong>Missing concept_id is a hard error, not a silent fallback:</strong> When <code>harness_meta.process_concept_id</code> is set in the FlowSpec but the named concept cannot be found in the registry, the run start fails with a <code>ProcessConceptNotFoundError</code>. A missing concept is a configuration error. Silently falling back to model-driven decomposition would mask a broken deployment and produce unexpectedly unguided runs.</div>
+  <div class="note-block"><strong>Concept files are immutable during a run:</strong> The registry caches loaded concepts by (path, mtime). Once a run starts and <code>initialize()</code> has called <code>seed_task_graph()</code>, changes to the concept file on disk have no effect on the active run. The seeded task graph is the live source of truth from that point forward.</div>
+</div>
+
+<div style="margin-bottom:1rem">
+  <div class="section-label">Unlocks after this phase completes</div>
+  <div class="next-card">
+    <div class="next-badge">P11 unblocked</div>
+    <div class="next-body"><strong>E2E Integration &amp; Testing</strong> — Phase 11 E2E tests can now exercise concept-seeded runs alongside model-driven runs. E2E-01 (happy path) gains a variant that seeds with <code>debug_test_failure</code> and confirms the concept's steps drive the task graph progression.</div>
+  </div>
+  <div class="next-card">
+    <div class="next-badge">Domain extensibility</div>
+    <div class="next-body"><strong>Custom concept authoring</strong> — With the registry's <code>scan_directory()</code> and the JSON schema in <code>concepts/concept_schema.json</code>, teams can add domain-specific concepts (e.g. <code>deploy_hotfix.json</code>, <code>triage_incident.json</code>) without any code changes. The canvas picker surfaces them automatically.</div>
+  </div>
+  <div class="next-card">
+    <div class="next-badge">Warm-start synergy</div>
+    <div class="next-body"><strong>Concept + experience_store convergence</strong> — Once both are active, concept-seeded runs populate the experience_store with execution data for each named step. Future warm_start() calls can load calibrated strategy priors per step ID, giving the harness increasingly refined behaviour on repeat task classes.</div>
+  </div>
+</div>
+
+</div>
+
+<!-- TASKS & STEPS -->
+<div id="tasks" class="tab-content">
+
+<div class="desc-block">P-PC.1 and P-PC.2 (data model + registry) should be completed first — all subsequent tasks depend on the <code>ProcessConcept</code> dataclass and the registry being stable. P-PC.3 (concept files) and P-PC.4 (loop integration) can proceed in parallel in week 2. P-PC.5 (schema wiring) should be done before P-PC.6 (canvas node) since the canvas node config shape is defined in the schema. P-PC.7 (integration tests) is last and exercises all prior tasks together.</div>
+
+<!-- P-PC.1 -->
+<div class="task-block" id="tb-ppc1">
+  <div class="task-header" onclick="toggleTask('ppc1')">
+    <span class="task-id">P-PC.1</span>
+    <span class="task-name">ProcessConcept and ProcessConceptStep dataclasses</span>
+    <span class="task-meta">Week 1 · ~2.5 days</span>
+  </div>
+  <div class="task-body" id="body-ppc1">
+    <div class="desc-block">Creates <code>adapter/harness/process_concept.py</code> with the core data model. <code>ProcessConceptStep</code> maps to a single <code>Task</code> in the task graph. <code>ProcessConcept</code> is the container holding all steps for a given task class. The <code>seed_task_graph()</code> method is the primary integration point — it converts the concept into a fully constructed <code>TaskGraph</code> ready for <code>validate_task_graph()</code>.</div>
+
+    <div class="steps-title">Implementation steps</div>
+
+    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Create <code>adapter/harness/process_concept.py</code> and define <code>ProcessConceptStep</code>.</strong> Fields: <code>id: str</code> (slug format — alphanumeric and underscores only, enforced by regex on construction), <code>description: str</code>, <code>depends_on: list[str]</code> (step IDs within the same concept), <code>risk_level: RiskLevel</code> (imported from <code>risk.py</code>), <code>abstraction_level: str</code> (must be one of <code>"leaf"</code> or <code>"subgoal"</code>), <code>expected_tools: list[str]</code> (advisory; cross-checked against <code>tool_availability_manifest</code> at init but not a run blocker), <code>success_criteria: str</code>, <code>strategy_hint: str | None = None</code> (must be a valid strategy name from the 6-strategy order in <code>recovery.py</code> if set). Implement <code>to_dict()</code> and <code>from_dict(d)</code> on the step.</div></div>
+
+    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Define <code>ProcessConcept</code> dataclass.</strong> Fields: <code>id: str</code>, <code>name: str</code>, <code>description: str</code>, <code>success_criteria: str</code> (top-level; individual steps carry their own per-step criteria), <code>schema_version: str</code> (must equal <code>"1.0"</code> — strict check; any other value raises <code>ProcessConceptValidationError</code> immediately), <code>steps: list[ProcessConceptStep]</code>. Define <code>ProcessConceptValidationError(ValueError)</code> as the typed exception raised for all structural violations.</div></div>
+
+    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Implement <code>ProcessConcept.validate()</code>.</strong> Three checks in order: (1) step ID uniqueness within the concept — duplicate IDs raise immediately; (2) <code>depends_on</code> reference validity — every ID in any step's <code>depends_on[]</code> must exist as a step ID in this concept (forward references are allowed — validation is over the complete step list, not incremental); (3) cycle detection — run a topological sort; any cycle raises <code>ProcessConceptValidationError</code> with the cycle path in the message. <code>validate()</code> is called by both <code>from_dict()</code> and <code>from_file()</code> before returning.</div></div>
+
+    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Implement <code>ProcessConcept.from_dict(d: dict)</code>.</strong> Parses the raw JSON dict: checks <code>schema_version</code> first, constructs <code>ProcessConceptStep</code> objects from <code>d["steps"]</code>, then calls <code>validate()</code>. If any field is missing or has the wrong type, raise <code>ProcessConceptValidationError</code> with the field path in the message. Never return a partially-constructed concept. Implement a symmetric <code>to_dict()</code> for serialisation to the journal.</div></div>
+
+    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Implement <code>ProcessConcept.seed_task_graph(objective: str) → TaskGraph</code>.</strong> Converts each <code>ProcessConceptStep</code> to a <code>Task</code> (imported from <code>task_graph.py</code>). Task IDs are namespaced as <code>{concept_id}:{step_id}</code> — raw step IDs never appear in the output task graph. <code>depends_on[]</code> entries are translated to the same namespaced format. <code>risk_level</code> and <code>abstraction_level</code> are copied directly. If <code>strategy_hint</code> is set, it is written to <code>task.assigned_strategy</code>. All tasks are initialised with status <code>PENDING</code>. Returns a fully constructed <code>TaskGraph</code> that can be passed directly to <code>validate_task_graph()</code>.</div></div>
+
+    <div class="section-label">Acceptance tests</div>
+    <div class="test-item"><code>from_dict()</code> raises <code>ProcessConceptValidationError</code> when a step's <code>depends_on</code> references a step ID that does not exist in the concept's step list — error message includes the missing ID</div>
+    <div class="test-item"><code>validate()</code> detects a two-step cycle (step A depends on step B, step B depends on step A) and raises <code>ProcessConceptValidationError</code> with the cycle path in the message</div>
+    <div class="test-item"><code>seed_task_graph()</code> produces a <code>TaskGraph</code> where all task IDs are namespaced as <code>{concept_id}:{step_id}</code> — no raw step IDs appear; confirmed by asserting no task ID equals any step ID from the source concept</div>
+    <div class="test-item"><code>seed_task_graph()</code> output passes <code>validate_task_graph()</code> without error for a well-formed 4-step concept with a linear dependency chain</div>
+  </div>
+</div>
+
+<!-- P-PC.2 -->
+<div class="task-block" id="tb-ppc2">
+  <div class="task-header" onclick="toggleTask('ppc2')">
+    <span class="task-id">P-PC.2</span>
+    <span class="task-name">ProcessRegistry — file-backed concept registry</span>
+    <span class="task-meta">Week 1 · ~1.5 days</span>
+  </div>
+  <div class="task-body" id="body-ppc2">
+    <div class="desc-block">Creates <code>adapter/harness/process_registry.py</code>. The registry maps concept IDs to file paths and handles loading with file-level caching keyed by (path, mtime). A module-level default registry instance is auto-populated from the <code>concepts/</code> directory at startup. Thread-safe for concurrent <code>load()</code> calls from parallel run starts.</div>
+
+    <div class="steps-title">Implementation steps</div>
+
+    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Create <code>adapter/harness/process_registry.py</code> and define <code>ProcessRegistry</code>.</strong> Internal state: <code>_registry: dict[str, Path]</code> mapping concept IDs to absolute file paths, <code>_cache: dict[tuple[Path, float], ProcessConcept]</code> keyed by (path, mtime). Define <code>ProcessConceptNotFoundError(KeyError)</code> as the typed exception for missing concept lookups. Use a <code>threading.Lock</code> to guard concurrent <code>load()</code> calls — parallel run starts may request the same concept simultaneously.</div></div>
+
+    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Implement <code>register(concept_id: str, path: str | Path)</code>.</strong> Resolves the path to absolute. Raises <code>ProcessConceptNotFoundError</code> immediately if the file does not exist at registration time — fail fast at startup, not at first use. Stores the mapping in <code>_registry</code>. Does not load the concept eagerly; loading is deferred to the first <code>load()</code> call so that startup is fast even with many registered concepts.</div></div>
+
+    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Implement <code>load(concept_id: str) → ProcessConcept</code>.</strong> Looks up the path in <code>_registry</code>; raises <code>ProcessConceptNotFoundError</code> with the missing ID in the message if not registered. Reads the file's current mtime. If <code>(path, mtime)</code> is in <code>_cache</code>: return the cached object. Otherwise: call <code>ProcessConcept.from_file(path)</code>, store in cache, and return. The mtime key means a concept file edited between runs is automatically reloaded without restarting the adapter.</div></div>
+
+    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Implement <code>list_available() → list[str]</code>.</strong> Returns a sorted list of all registered concept IDs. Used by the canvas process_concept node to populate the concept picker dropdown. Also useful for debugging and the adapter's <code>GET /concepts</code> endpoint (if added in P-PC.5).</div></div>
+
+    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Implement <code>scan_directory(dir_path: str | Path)</code>.</strong> Walks the directory for all <code>*.json</code> files. For each file: attempts to read its <code>id</code> field from the JSON without fully parsing (fast peek), then calls <code>register(concept_id, path)</code>. Files that fail JSON parsing or are missing the <code>id</code> field are logged as a warning and skipped — the scan never aborts due to a single malformed file. Create a module-level <code>DEFAULT_REGISTRY = ProcessRegistry()</code> and call <code>DEFAULT_REGISTRY.scan_directory("concepts/")</code> at module import time if the directory exists.</div></div>
+
+    <div class="section-label">Acceptance tests</div>
+    <div class="test-item"><code>register()</code> raises <code>ProcessConceptNotFoundError</code> when called with a path that does not exist on disk — the error message includes the path</div>
+    <div class="test-item"><code>load()</code> on an unregistered concept_id raises <code>ProcessConceptNotFoundError</code> with the missing ID in the message; a second call with the same ID raises the same error without side effects</div>
+    <div class="test-item"><code>scan_directory()</code> registers all valid JSON files in a temp directory and logs exactly one warning (without raising) for a file with invalid JSON structure — the other valid files are still registered</div>
+    <div class="test-item"><code>list_available()</code> returns concept IDs in sorted alphabetical order; after <code>scan_directory()</code> on a directory with 3 valid concept files it returns a list of length 3</div>
+  </div>
+</div>
+
+<!-- P-PC.3 -->
+<div class="task-block" id="tb-ppc3">
+  <div class="task-header" onclick="toggleTask('ppc3')">
+    <span class="task-id">P-PC.3</span>
+    <span class="task-name">Bundled concept JSON files and JSON schema</span>
+    <span class="task-meta">Week 2 · ~1.5 days</span>
+  </div>
+  <div class="task-body" id="body-ppc3">
+    <div class="desc-block">Creates the <code>concepts/</code> directory containing a formal JSON schema (<code>concept_schema.json</code>) and four domain concept files. Each concept file is validated against the schema on load. The four concepts cover the most common AI coding agent task classes: debugging a failing test, implementing a new feature, reviewing code, and refactoring a module.</div>
+
+    <div class="steps-title">Implementation steps</div>
+
+    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Create <code>concepts/concept_schema.json</code>.</strong> A JSON Schema (draft-07) document covering all fields of <code>ProcessConcept</code> and <code>ProcessConceptStep</code>. Top-level required fields: <code>id</code>, <code>name</code>, <code>description</code>, <code>success_criteria</code>, <code>schema_version</code>, <code>steps</code>. Per-step required fields: <code>id</code>, <code>description</code>, <code>depends_on</code>, <code>risk_level</code>, <code>abstraction_level</code>, <code>expected_tools</code>, <code>success_criteria</code>. <code>strategy_hint</code> is optional and its enum must match the 6 strategy names. <code>risk_level</code> enum: <code>"LOW"</code>, <code>"MEDIUM"</code>, <code>"HIGH"</code>. <code>abstraction_level</code> enum: <code>"leaf"</code>, <code>"subgoal"</code>. Add schema validation via <code>jsonschema</code> in <code>ProcessConcept.from_dict()</code> — validation runs before field parsing.</div></div>
+
+    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Create <code>concepts/debug_test_failure.json</code>.</strong> 6 steps: <code>read_test</code> (read the failing test, LOW) → <code>run_test</code> (capture live failure output, LOW, expected_tools: ["bash"]) → <code>locate_source</code> (trace stack to source, LOW, expected_tools: ["read_file","grep"]) → <code>form_hypothesis</code> (state root cause and predicted fix, LOW) → <code>apply_fix</code> (apply minimal change, MEDIUM, strategy_hint: "MINIMAL_FIX", expected_tools: ["edit_file"]) → <code>verify_fix</code> (re-run suite, check regressions, LOW, expected_tools: ["bash"]). Linear dependency chain.</div></div>
+
+    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Create <code>concepts/implement_feature.json</code>.</strong> 7 steps: <code>read_requirements</code> (LOW) is the entry point. <code>survey_codebase</code> (LOW, expected_tools: ["grep","read_file"]) and <code>design_interface</code> (LOW, abstraction_level: "subgoal") both depend on <code>read_requirements</code> — this is the only concept with a parallel fan-out. <code>implement</code> (MEDIUM, expected_tools: ["edit_file"]) depends on both <code>survey_codebase</code> and <code>design_interface</code>. <code>write_tests</code> (LOW, expected_tools: ["edit_file"]) depends on <code>implement</code>. <code>run_tests</code> (LOW, expected_tools: ["bash"]) depends on <code>write_tests</code>. <code>refine</code> (LOW) depends on <code>run_tests</code>. This concept tests the parallel fan-out and re-join in <code>seed_task_graph()</code>.</div></div>
+
+    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Create <code>concepts/code_review.json</code>.</strong> 5 steps, strictly sequential: <code>read_diff</code> (LOW, expected_tools: ["read_file","bash"]) → <code>check_logic_correctness</code> (LOW) → <code>check_test_coverage</code> (LOW) → <code>check_code_style</code> (LOW) → <code>summarise_findings</code> (LOW). No parallel steps, no strategy hints. The simplest concept — used as the baseline fixture in integration tests where minimal complexity is needed.</div></div>
+
+    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Create <code>concepts/refactor_module.json</code>.</strong> 7 steps: <code>read_current</code> (LOW, expected_tools: ["read_file"]) → <code>run_tests_baseline</code> (LOW, expected_tools: ["bash"]) → <code>identify_hotspots</code> (LOW, strategy_hint: "BROADER_SEARCH", expected_tools: ["grep","read_file"]) → <code>design_target</code> (LOW, abstraction_level: "subgoal") → <code>apply_refactor</code> (HIGH, expected_tools: ["edit_file"]) → <code>run_tests_post</code> (LOW, expected_tools: ["bash"]) → <code>verify_no_regression</code> (LOW). The <code>apply_refactor</code> step with risk_level HIGH verifies that the HIGH-risk path in the execution and verification layers is exercised when this concept seeds the task graph.</div></div>
+
+    <div class="section-label">Acceptance tests</div>
+    <div class="test-item">All 4 bundled concept files parse via <code>ProcessConcept.from_file()</code> without error and each passes <code>validate()</code> — confirmed by asserting no exception is raised and returned objects have the correct step counts (6, 7, 5, 7)</div>
+    <div class="test-item"><code>implement_feature.json</code> encodes the parallel fan-out correctly: <code>survey_codebase</code> and <code>design_interface</code> both list <code>read_requirements</code> in their <code>depends_on[]</code>; after <code>seed_task_graph()</code> the <code>implement</code> task depends on both namespaced IDs</div>
+    <div class="test-item"><code>refactor_module.json</code> produces an <code>apply_refactor</code> task with <code>risk_level=HIGH</code> after <code>seed_task_graph()</code> — confirmed by iterating the returned task graph and asserting the task with the expected namespaced ID has the HIGH risk level</div>
+    <div class="test-item">JSON schema validation (<code>concept_schema.json</code>) correctly rejects a concept file where one step has <code>"risk_level": "CRITICAL"</code> (not in the enum) — <code>ProcessConceptValidationError</code> is raised and its message references the invalid field</div>
+  </div>
+</div>
+
+<!-- P-PC.4 -->
+<div class="task-block" id="tb-ppc4">
+  <div class="task-header" onclick="toggleTask('ppc4')">
+    <span class="task-id">P-PC.4</span>
+    <span class="task-name">loop.py initialize() integration</span>
+    <span class="task-meta">Week 2 · ~2 days</span>
+  </div>
+  <div class="task-body" id="body-ppc4">
+    <div class="desc-block">Modifies <code>adapter/harness/loop.py</code> to accept an optional <code>process_concept</code> parameter in <code>initialize()</code>. When provided, <code>seed_task_graph(objective)</code> pre-populates the task graph before the existing <code>decomposition_gate()</code> call. All existing gates, invariants, and post-init paths are unchanged. The <code>process_concept=None</code> path is structurally identical to the pre-concept code.</div>
+
+    <div class="steps-title">Implementation steps</div>
+
+    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Add <code>process_concept: ProcessConcept | None = None</code> to <code>initialize()</code> in <code>loop.py</code>.</strong> Import <code>ProcessConcept</code> from <code>process_concept.py</code>. Update the function signature — no other code changes required for the <code>None</code> branch since the entire seeding block is guarded by <code>if process_concept is not None</code>. The parameter is keyword-only to prevent positional argument breakage in existing callers.</div></div>
+
+    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Insert the seeding block at the start of <code>initialize()</code>, before <code>decomposition_gate()</code>.</strong> The block: <code>if process_concept is not None: state.task_graph = process_concept.seed_task_graph(state.objective)</code>. Write the concept ID and step count to the journal: <code>log_journal(f"Seeded task_graph from concept '{process_concept.id}' ({len(process_concept.steps)} steps)")</code>. If <code>process_concept is None</code>: the <code>task_graph</code> field of <code>HarnessRunState</code> remains empty — the model will populate it via the existing <code>update_task_graph()</code> path.</div></div>
+
+    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Confirm the existing gate sequence is unchanged for both branches.</strong> After the seeding block (or its absence), the code continues to <code>validate_task_graph()</code> and then <code>decomposition_gate()</code> exactly as before. Do not add a conditional skip of these gates for the concept-seeded branch — the gates are not bypassed. A concept that seeds a task graph misaligned with the objective is caught and handled by the existing gate logic. Document this with a comment.</div></div>
+
+    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Confirm <code>warm_start(experience_store)</code> is called after the seeding block.</strong> It already is in the existing initialization sequence. Add a comment at the call site: <code># warm_start enriches strategy_state.prior_strategy_weights; called after seed_task_graph() so experience priors layer on top of the concept structure</code>. Assert in the test suite that warm_start does not replace the seeded task_graph (see acceptance tests below).</div></div>
+
+    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Add <code>process_concept_id: str | None</code> to <code>HarnessRunState</code> in <code>state_store.py</code>.</strong> This field carries the concept ID for observability — it is written at initialization and visible in the journal and harness-state API response. It is not the <code>ProcessConcept</code> object itself (which is not serialised to the state store). Update <code>to_dict()</code> and <code>from_dict()</code>. Export from <code>adapter/harness/__init__.py</code>.</div></div>
+
+    <div class="section-label">Acceptance tests</div>
+    <div class="test-item">When <code>process_concept=None</code>: <code>initialize()</code> produces a <code>HarnessRunState</code> with an empty task_graph (no tasks) — structurally identical to all P0–P9 run initializations (regression guard)</div>
+    <div class="test-item">When a valid <code>ProcessConcept</code> with 6 steps is provided: the returned <code>HarnessRunState.task_graph</code> contains exactly 6 tasks, all with status PENDING, and <code>state.process_concept_id</code> equals the concept's ID</div>
+    <div class="test-item"><code>decomposition_gate()</code> is called after seeding and is not bypassed — confirmed by a fixture that provides a concept whose steps are misaligned with the objective; asserting the gate returns GATHER_CLARIFICATION (not PROCEED)</div>
+    <div class="test-item"><code>warm_start()</code> is called after seeding and its return value updates <code>strategy_state.prior_strategy_weights</code> without replacing or clearing the seeded task_graph — task count remains 6 after warm_start completes</div>
+  </div>
+</div>
+
+<!-- P-PC.5 -->
+<div class="task-block" id="tb-ppc5">
+  <div class="task-header" onclick="toggleTask('ppc5')">
+    <span class="task-id">P-PC.5</span>
+    <span class="task-name">FlowSpec harness_meta extension and run-start wiring</span>
+    <span class="task-meta">Week 3 · ~1.5 days</span>
+  </div>
+  <div class="task-body" id="body-ppc5">
+    <div class="desc-block">Extends the FlowSpec <code>harness_meta</code> block with an optional <code>process_concept_id</code> field. Updates <code>adapter/validate.py</code> and wires <code>adapter/run_api.py</code> to load the named concept from the registry at run start and pass it to <code>initialize()</code>. Establishes the clear error semantics: absent field → unchanged behaviour; present and found → seeded run; present and not found → hard configuration error.</div>
+
+    <div class="steps-title">Implementation steps</div>
+
+    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Add <code>process_concept_id: z.string().optional()</code> to the <code>harness_meta</code> shape in <code>spec/schema.ts</code>.</strong> The field is optional — existing flows that omit it parse without error and behave identically to before. Regenerate <code>spec/schema.json</code>. No migration script is needed since the field is optional and all existing flows are forward-compatible.</div></div>
+
+    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Update <code>adapter/validate.py</code> to accept <code>process_concept_id</code> in <code>harness_meta</code>.</strong> Validation rule: if the field is present, it must be a non-empty string (reject empty string with a clear message). The adapter does not validate that the ID exists in the registry at flow-validation time — concept availability is a runtime concern, not a spec-validity concern. A valid spec with a missing concept fails at run start, not at validation time.</div></div>
+
+    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Add a module-level <code>DEFAULT_REGISTRY</code> to <code>adapter/run_api.py</code>.</strong> At module import: instantiate <code>ProcessRegistry()</code> and call <code>scan_directory(Path("concepts/"))</code> if the directory exists. Log the number of concepts found at INFO level. If the directory is absent: log at DEBUG and continue — the registry is empty, which is valid (it just means no concepts are available).</div></div>
+
+    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Wire the run-start concept load in <code>run_api.py</code>'s harness run handler.</strong> After loading the flow spec: if <code>harness_meta.process_concept_id</code> is set, call <code>DEFAULT_REGISTRY.load(concept_id)</code>. If <code>ProcessConceptNotFoundError</code> is raised: return a 400 response with the message <code>"process_concept_id '{id}' not found in registry — check that the concept file exists in the concepts/ directory"</code>. Do not fall back to <code>None</code>. Pass the loaded concept to <code>initialize()</code>. If the field is absent: pass <code>process_concept=None</code>.</div></div>
+
+    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Add <code>GET /concepts</code> endpoint to <code>run_api.py</code>.</strong> Returns a JSON list of available concept summaries: <code>[{"id": "...", "name": "...", "description": "...", "step_count": N}]</code> for each registered concept. Used by the canvas node's concept picker dropdown to enumerate available options without requiring a full concept load. Response is sorted by concept ID. Returns an empty array if no concepts are registered — not a 404.</div></div>
+
+    <div class="section-label">Acceptance tests</div>
+    <div class="test-item">A flow spec with <code>harness_meta.process_concept_id = "debug_test_failure"</code> passes <code>adapter/validate.py</code> without error; a spec with <code>process_concept_id = ""</code> (empty string) fails validation with a message containing "non-empty"</div>
+    <div class="test-item">Run start with a valid concept ID loads the concept from the registry and passes it to <code>initialize()</code> — confirmed by asserting <code>HarnessRunState.process_concept_id</code> equals the requested ID and <code>task_graph</code> contains the concept's step count</div>
+    <div class="test-item">Run start with <code>process_concept_id = "nonexistent_concept"</code> returns a 400 response containing the missing ID and the words "not found in registry" — it does not start a run with an empty task_graph</div>
+    <div class="test-item"><code>GET /concepts</code> returns all 4 bundled concepts after <code>scan_directory("concepts/")</code> runs at startup; each entry has the correct <code>step_count</code> matching the number of steps in the corresponding JSON file</div>
+  </div>
+</div>
+
+<!-- P-PC.6 -->
+<div class="task-block" id="tb-ppc6">
+  <div class="task-header" onclick="toggleTask('ppc6')">
+    <span class="task-id">P-PC.6</span>
+    <span class="task-name">Canvas process_concept node type</span>
+    <span class="task-meta">Week 3 · ~2 days</span>
+  </div>
+  <div class="task-body" id="body-ppc6">
+    <div class="desc-block">Adds the <code>process_concept</code> canvas node type. Lets flow authors pick a concept from the registry, preview its ordered steps with risk badges and dependency arrows, and observe live task status per step during an active run. The canvas node writes the <code>process_concept_id</code> into <code>harness_meta</code> — it does not generate standalone adapter calls.</div>
+
+    <div class="steps-title">Implementation steps</div>
+
+    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Add <code>ProcessConceptNodeConfig</code> shape to <code>spec/schema.ts</code>.</strong> Fields: <code>concept_id: string</code> (required when the node is present in a flow), <code>show_steps: boolean</code> (default <code>true</code>), <code>show_step_dependencies: boolean</code> (default <code>true</code>), <code>max_steps_shown: number</code> (default 20). Regenerate <code>spec/schema.json</code> and update <code>adapter/validate.py</code> to validate the config shape.</div></div>
+
+    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Create <code>src/components/nodes/harness/ProcessConceptNode.tsx</code>.</strong> Node header: concept name (fetched from <code>GET /concepts</code> on mount) and concept ID in the phase accent colour. Node body (when <code>show_steps=true</code>): an ordered list of step rows, each showing step sequence number, description (truncated to 80 chars), risk_level badge (LOW=slate, MEDIUM=amber, HIGH=red), and — when set — a <code>strategy_hint</code> chip in a muted accent colour. A step count chip in the header shows the total number of steps.</div></div>
+
+    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Implement the concept picker.</strong> In the node's config panel: a dropdown populated by <code>GET /concepts</code> showing concept name and step count for each available concept. Selecting a concept updates <code>node_config.concept_id</code> and re-renders the step list. If the concepts endpoint is unavailable (adapter not running): show a "Registry unavailable — enter concept ID manually" fallback with a text input. The node never blocks flow authoring due to registry connectivity.</div></div>
+
+    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Implement the step dependency visualization.</strong> When <code>show_step_dependencies=true</code>: draw SVG connector lines between step rows that have <code>depends_on</code> relationships — entry-point steps (no <code>depends_on</code>) are left-aligned; dependent steps are slightly indented. For the <code>implement_feature</code> concept: both <code>survey_codebase</code> and <code>design_interface</code> draw connector lines from <code>read_requirements</code>, and <code>implement</code> draws lines from both — this visually communicates the fan-out/re-join structure.</div></div>
+
+    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Implement the live run overlay and register the node type.</strong> During an active harness run: poll <code>GET /runs/{run_id}/harness-state</code> at the same 2-second interval as other harness nodes. Cross-reference each step's namespaced task ID against the live task_graph state. Overlay the task status badge (PENDING/ACTIVE/VERIFYING/COMPLETE/FAILED/BLOCKED) on the step row. Register <code>"process_concept"</code> in <code>packages/canvas/nodeTypes.ts</code>. Add <code>compile_process_concept_node(node_config)</code> to <code>adapter/harness/node_compilers.py</code> — it emits <code>node_config.concept_id</code> into the flow's <code>harness_meta.process_concept_id</code> field and generates no standalone adapter calls. Export from <code>adapter/harness/__init__.py</code>.</div></div>
+
+    <div class="section-label">Acceptance tests</div>
+    <div class="test-item">Step rows render with correct risk_level badge colours from a <code>refactor_module</code> fixture: LOW steps show slate badges, MEDIUM would show amber (none in this concept), HIGH (<code>apply_refactor</code>) shows a red badge</div>
+    <div class="test-item">Dependency arrows render between the correct step rows for the <code>implement_feature</code> concept: <code>survey_codebase</code> and <code>design_interface</code> both show a connector line from <code>read_requirements</code>; <code>implement</code> shows connector lines from both of them</div>
+    <div class="test-item">Live run overlay: steps whose namespaced task IDs are COMPLETE in the fixture show a green COMPLETE badge; steps that are PENDING show no status overlay — confirmed from a mixed-status fixture with 3 COMPLETE and 3 PENDING tasks</div>
+    <div class="test-item"><code>compile_process_concept_node({"concept_id": "debug_test_failure", ...})</code> produces output that sets <code>harness_meta.process_concept_id = "debug_test_failure"</code> in the compiled FlowSpec; it does not emit any standalone adapter function call</div>
+  </div>
+</div>
+
+<!-- P-PC.7 -->
+<div class="task-block" id="tb-ppc7">
+  <div class="task-header" onclick="toggleTask('ppc7')">
+    <span class="task-id">P-PC.7</span>
+    <span class="task-name">Integration tests and cross-component wiring verification</span>
+    <span class="task-meta">Week 4 · ~2 days</span>
+  </div>
+  <div class="task-body" id="body-ppc7">
+    <div class="desc-block">Creates <code>adapter/tests/test_harness_process_concepts.py</code> with end-to-end integration tests, invariant tests, and regression guards. Uses the in-memory session fixture from P8 — no Postgres required. Runs the full P0–P9 test suite to confirm no regressions from the <code>loop.py</code> and <code>state_store.py</code> changes.</div>
+
+    <div class="steps-title">Implementation steps</div>
+
+    <div class="step"><span class="step-num">1</span><div class="step-body"><strong>Write four end-to-end path tests.</strong> Each test exercises the full path: concept JSON file → <code>ProcessRegistry.load()</code> → <code>initialize(process_concept=concept)</code> → one loop iteration → assert task graph state. Use <code>debug_test_failure</code> and <code>implement_feature</code> as the test fixtures. Confirm that the seeded task graph's first leaf task (no <code>depends_on</code>) is selected by <code>select_unblocked_leaf()</code> and becomes ACTIVE. Use the in-memory session fixture from P8 — no live adapter or Postgres required.</div></div>
+
+    <div class="step"><span class="step-num">2</span><div class="step-body"><strong>Write INV-PC-01 test: concept is a prior, not a constraint.</strong> Seed the task graph from <code>code_review</code> (5 steps). Run <code>initialize()</code>. Then force a verification failure on the first task, triggering <code>diagnose_and_replan()</code>. Assert that replanning successfully adds a new task not present in the original concept — <code>task_graph.tasks</code> length exceeds 5 after replan. The concept's step IDs remain in the graph but the graph is no longer limited to them.</div></div>
+
+    <div class="step"><span class="step-num">3</span><div class="step-body"><strong>Write INV-PC-03 test: process_concept=None leaves harness structurally unchanged.</strong> Call <code>initialize(process_concept=None)</code>. Assert the returned <code>HarnessRunState</code> has an empty <code>task_graph</code> (zero tasks). Assert that <code>HarnessRunState.process_concept_id</code> is <code>None</code>. Assert that all fields present in a standard P0-era harness state are present and have their expected default values — no new required fields, no structural changes to the None-path run.</div></div>
+
+    <div class="step"><span class="step-num">4</span><div class="step-body"><strong>Write schema round-trip tests for all 4 bundled concepts.</strong> For each concept: load via <code>from_file()</code>, call <code>seed_task_graph("placeholder objective")</code>, validate the resulting <code>TaskGraph</code> via <code>validate_task_graph()</code>. Assert that every step's <code>risk_level</code>, <code>depends_on[]</code> (namespaced), and <code>strategy_hint</code> (when set) are correctly reflected in the corresponding <code>Task</code> objects. No information loss permitted.</div></div>
+
+    <div class="step"><span class="step-num">5</span><div class="step-body"><strong>Run the full P0–P9 regression suite and confirm 208/208 pass.</strong> Execute <code>pytest adapter/tests/ -v -k harness</code>. All existing tests must pass — the parameter addition to <code>initialize()</code> and the new optional field on <code>HarnessRunState</code> must not break any existing test. Fix any regression before marking this task complete. Record the final passing count in a summary comment at the top of <code>test_harness_process_concepts.py</code>.</div></div>
+
+    <div class="section-label">Acceptance tests</div>
+    <div class="test-item">Full path integration: <code>scan_directory("concepts/") → load("debug_test_failure") → initialize(process_concept=concept)</code> produces a <code>HarnessRunState</code> with 6 tasks, all PENDING, with namespaced IDs of the form <code>"debug_test_failure:{step_id}"</code></div>
+    <div class="test-item">INV-PC-01: a replanning call during a <code>code_review</code>-seeded run successfully adds a task not defined in the original concept; <code>len(task_graph.tasks) > 5</code> after the replan — the concept did not prevent the graph from growing</div>
+    <div class="test-item">INV-PC-03: <code>initialize(process_concept=None)</code> produces a <code>HarnessRunState</code> with zero tasks in <code>task_graph</code> and <code>process_concept_id=None</code> — structurally identical to all pre-concept P0–P9 test fixtures</div>
+    <div class="test-item">208/208 P0–P9 acceptance tests pass after all process concepts changes land — confirmed by running <code>pytest adapter/tests/ -v -k harness</code> and asserting exit code 0</div>
+  </div>
+</div>
+
+</div>
+
+<!-- FILE MAP -->
+<div id="files" class="tab-content">
+
+<div class="card">
+  <div class="card-title">Files created or modified in this phase</div>
+  <div class="card-body" style="margin-bottom:.7rem">Green = new file. Amber = existing file modified. This phase is primarily a Python adapter layer change — the bulk of new code is in the harness core and the concepts directory. The frontend side receives one new canvas node and minor schema updates.</div>
+
+  <div class="file-map">
+<span class="f-dir">adapter/harness/</span>
+  process_concept.py                    <span class="f-new">NEW</span>  <span class="f-note">ProcessConceptStep · ProcessConcept · ProcessConceptValidationError · from_dict · from_file · seed_task_graph · to_dict · validate</span>
+  process_registry.py                   <span class="f-new">NEW</span>  <span class="f-note">ProcessRegistry · ProcessConceptNotFoundError · register · load · list_available · scan_directory · DEFAULT_REGISTRY module instance</span>
+  __init__.py                           <span class="f-mod">MOD</span>  <span class="f-note">export ProcessConcept · ProcessConceptStep · ProcessConceptValidationError · ProcessRegistry · ProcessConceptNotFoundError · DEFAULT_REGISTRY</span>
+  loop.py                               <span class="f-mod">MOD</span>  <span class="f-note">add process_concept keyword parameter to initialize() · seeding block before decomposition_gate() · journal log entry on seed · warm_start comment</span>
+  state_store.py                        <span class="f-mod">MOD</span>  <span class="f-note">add process_concept_id: str | None field to HarnessRunState · update to_dict/from_dict</span>
+  node_compilers.py                     <span class="f-mod">MOD</span>  <span class="f-note">add compile_process_concept_node — emits concept_id into harness_meta, no standalone adapter calls</span>
+
+<span class="f-dir">concepts/</span>  <span class="f-new">NEW DIR</span>
+  concept_schema.json                   <span class="f-new">NEW</span>  <span class="f-note">JSON Schema draft-07 covering ProcessConcept + ProcessConceptStep; all concept files validated against this on load</span>
+  debug_test_failure.json               <span class="f-new">NEW</span>  <span class="f-note">6 steps: read_test → run_test → locate_source → form_hypothesis → apply_fix (MINIMAL_FIX hint) → verify_fix</span>
+  implement_feature.json                <span class="f-new">NEW</span>  <span class="f-note">7 steps: parallel fan-out (survey_codebase + design_interface both from read_requirements) re-joining at implement</span>
+  code_review.json                      <span class="f-new">NEW</span>  <span class="f-note">5 steps: read_diff → check_logic_correctness → check_test_coverage → check_code_style → summarise_findings (linear)</span>
+  refactor_module.json                  <span class="f-new">NEW</span>  <span class="f-note">7 steps: includes apply_refactor (risk_level: HIGH) and identify_hotspots (strategy_hint: BROADER_SEARCH)</span>
+
+<span class="f-dir">spec/</span>
+  schema.ts                             <span class="f-mod">MOD</span>  <span class="f-note">add process_concept_id: z.string().optional() to harness_meta block · add ProcessConceptNodeConfig shape</span>
+  schema.json                           <span class="f-mod">MOD</span>  <span class="f-note">regenerated from schema.ts</span>
+
+<span class="f-dir">src/components/nodes/harness/</span>
+  ProcessConceptNode.tsx                <span class="f-new">NEW</span>  <span class="f-note">concept picker · ordered step list · risk badges · strategy_hint chips · dependency arrows · live run overlay</span>
+  index.tsx                             <span class="f-mod">MOD</span>  <span class="f-note">export ProcessConceptNode alongside existing harness node components</span>
+
+<span class="f-dir">packages/canvas/</span>
+  nodeTypes.ts                          <span class="f-mod">MOD</span>  <span class="f-note">register "process_concept" node type with ProcessConceptNode component and default config</span>
+  nodeDefaults.ts                       <span class="f-mod">MOD</span>  <span class="f-note">default ProcessConceptNodeConfig values (show_steps: true, show_step_dependencies: true, max_steps_shown: 20)</span>
+
+<span class="f-dir">adapter/</span>
+  validate.py                           <span class="f-mod">MOD</span>  <span class="f-note">accept process_concept_id in harness_meta (non-empty string if present) · add ProcessConceptNodeConfig shape validation</span>
+  run_api.py                            <span class="f-mod">MOD</span>  <span class="f-note">DEFAULT_REGISTRY module instance · scan_directory at startup · concept load at run start · 400 on missing concept · GET /concepts endpoint</span>
+
+<span class="f-dir">adapter/tests/</span>
+  test_harness_process_concepts.py      <span class="f-new">NEW</span>  <span class="f-note">all 28 acceptance tests (T01–T28) · in-memory session fixture (no Postgres) · INV-PC-01 + INV-PC-03 invariant tests · P0–P9 regression guard</span>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-title">Files NOT touched in this phase</div>
+  <div class="card-body">All existing harness logic modules are untouched except for <code>loop.py</code> (parameter addition) and <code>state_store.py</code> (one optional field). In particular, the following are unchanged:
+  <code style="font-family:var(--font-mono);font-size:11px;background:var(--bg2);padding:1px 5px;border-radius:3px">world_model.py</code>
+  <code style="font-family:var(--font-mono);font-size:11px;background:var(--bg2);padding:1px 5px;border-radius:3px">task_graph.py</code>
+  <code style="font-family:var(--font-mono);font-size:11px;background:var(--bg2);padding:1px 5px;border-radius:3px">control_state.py</code>
+  <code style="font-family:var(--font-mono);font-size:11px;background:var(--bg2);padding:1px 5px;border-radius:3px">diagnostics.py</code>
+  <code style="font-family:var(--font-mono);font-size:11px;background:var(--bg2);padding:1px 5px;border-radius:3px">verification.py</code>
+  <code style="font-family:var(--font-mono);font-size:11px;background:var(--bg2);padding:1px 5px;border-radius:3px">recovery.py</code>
+  <code style="font-family:var(--font-mono);font-size:11px;background:var(--bg2);padding:1px 5px;border-radius:3px">reviewer.py</code>
+  <code style="font-family:var(--font-mono);font-size:11px;background:var(--bg2);padding:1px 5px;border-radius:3px">experience_store.py</code>. All four framework adapters are unchanged — the process concept is consumed entirely within the harness layer before the framework adapter receives any task.</div>
+</div>
+
+</div>
+
+<!-- DEPENDENCIES -->
+<div id="deps" class="tab-content">
+
+<div class="card">
+  <div class="card-title">Intra-phase task ordering</div>
+  <div class="card-body">P-PC.1 and P-PC.2 must be completed first — they define the data model and registry that every other task depends on. P-PC.3 and P-PC.4 can proceed in parallel in week 2 once P-PC.1 and P-PC.2 are stable. P-PC.5 should precede P-PC.6 since the canvas node config shape (<code>ProcessConceptNodeConfig</code>) is defined in the schema step. P-PC.7 is last — it requires all prior tasks to be in place and exercises them together.</div>
+</div>
+
+<table class="dep-table">
+<thead><tr><th>Task</th><th>Depends on</th><th>Reason</th></tr></thead>
+<tbody>
+<tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.1 — ProcessConcept dataclasses</td><td><em style="color:var(--t1)">none</em></td><td style="font-size:11.5px;color:var(--t1)">Foundation — all other tasks import from <code>process_concept.py</code></td></tr>
+<tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.2 — ProcessRegistry</td><td><span class="dep-tag">P-PC.1</span></td><td style="font-size:11.5px;color:var(--t1)">Registry calls <code>ProcessConcept.from_file()</code> — requires the dataclass to be stable</td></tr>
+<tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.3 — Bundled concept files</td><td><span class="dep-tag">P-PC.1</span></td><td style="font-size:11.5px;color:var(--t1)">Files are validated by <code>from_file()</code> on load; the dataclass schema must be final before writing the files</td></tr>
+<tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.4 — loop.py integration</td><td><span class="dep-tag">P-PC.1</span><span class="dep-tag">P-PC.2</span></td><td style="font-size:11.5px;color:var(--t1)"><code>initialize()</code> imports <code>ProcessConcept</code> (P-PC.1) and the registry is used by the run-start path (P-PC.2)</td></tr>
+<tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.5 — Schema + run_api.py wiring</td><td><span class="dep-tag">P-PC.2</span><span class="dep-tag">P-PC.4</span></td><td style="font-size:11.5px;color:var(--t1)"><code>run_api.py</code> calls <code>registry.load()</code> (P-PC.2) and passes the result to <code>initialize()</code> (P-PC.4)</td></tr>
+<tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.6 — Canvas node</td><td><span class="dep-tag">P-PC.5</span></td><td style="font-size:11.5px;color:var(--t1)"><code>ProcessConceptNodeConfig</code> is defined in the schema step (P-PC.5.1); <code>GET /concepts</code> endpoint (P-PC.5.5) must exist for the picker</td></tr>
+<tr><td style="color:var(--ppc);font-family:var(--font-mono);font-size:11px;font-weight:600">P-PC.7 — Integration tests</td><td><span class="dep-tag">P-PC.1</span><span class="dep-tag">P-PC.2</span><span class="dep-tag">P-PC.3</span><span class="dep-tag">P-PC.4</span><span class="dep-tag">P-PC.5</span></td><td style="font-size:11.5px;color:var(--t1)">End-to-end tests exercise the full path across all prior tasks; P-PC.6 canvas tests are frontend-only and not required for the backend integration tests</td></tr>
+</tbody>
+</table>
+
+<div class="card" style="margin-top:.75rem">
+  <div class="card-title">Cross-phase dependencies: what this phase requires from earlier phases</div>
+  <table class="dep-table" style="margin-top:.5rem;margin-bottom:0">
+  <thead><tr><th>Earlier task</th><th>Used in</th><th>What is needed</th></tr></thead>
+  <tbody>
+  <tr><td style="font-family:var(--font-mono);font-size:11px;color:var(--blue)">P0.6 — HarnessRunState + harness-state API</td><td><span class="dep-tag">P-PC.4</span><span class="dep-tag">P-PC.6</span></td><td style="font-size:11.5px;color:var(--t1)"><code>HarnessRunState</code> is extended with <code>process_concept_id</code>; the canvas node polls the harness-state endpoint for live run overlay</td></tr>
+  <tr><td style="font-family:var(--font-mono);font-size:11px;color:var(--green)">P4.1 — TaskGraph and Task dataclasses</td><td><span class="dep-tag">P-PC.1</span></td><td style="font-size:11.5px;color:var(--t1)"><code>seed_task_graph()</code> constructs <code>Task</code> objects; the 6-state status, <code>depends_on[]</code>, <code>risk_level</code>, and <code>abstraction_level</code> fields must all be present on <code>Task</code></td></tr>
+  <tr><td style="font-family:var(--font-mono);font-size:11px;color:var(--green)">P4.2 — validate_task_graph()</td><td><span class="dep-tag">P-PC.1</span><span class="dep-tag">P-PC.4</span></td><td style="font-size:11.5px;color:var(--t1)"><code>seed_task_graph()</code> output is validated by the same gate as model-driven decompositions; the gate must be able to handle a pre-populated task graph</td></tr>
+  <tr><td style="font-family:var(--font-mono);font-size:11px;color:var(--green)">P4.3 — decomposition_gate()</td><td><span class="dep-tag">P-PC.4</span></td><td style="font-size:11.5px;color:var(--t1)">The gate is called after seeding and must return PROCEED / GATHER_CLARIFICATION / ESCALATE against the seeded graph — same interface as for empty graphs</td></tr>
+  <tr><td style="font-family:var(--font-mono);font-size:11px;color:var(--red)">P5.3 — risk.py RiskLevel enum</td><td><span class="dep-tag">P-PC.1</span></td><td style="font-size:11.5px;color:var(--t1)"><code>ProcessConceptStep.risk_level</code> imports <code>RiskLevel</code> from <code>risk.py</code> — the enum must include LOW, MEDIUM, and HIGH values</td></tr>
+  <tr><td style="font-family:var(--font-mono);font-size:11px;color:var(--red)">P6.2 — strategy names in recovery.py</td><td><span class="dep-tag">P-PC.1</span></td><td style="font-size:11.5px;color:var(--t1)"><code>ProcessConceptStep.strategy_hint</code> validation checks the value against the 6 strategy names defined in <code>recovery.py</code></td></tr>
+  <tr><td style="font-family:var(--font-mono);font-size:11px;color:var(--slate)">P8.1 — warm_start() + experience_store</td><td><span class="dep-tag">P-PC.4</span></td><td style="font-size:11.5px;color:var(--t1)"><code>warm_start()</code> is called after <code>seed_task_graph()</code>; its no-op contract when <code>experience_store.available=False</code> must hold in the seeded path</td></tr>
+  <tr><td style="font-family:var(--font-mono);font-size:11px;color:var(--pink)">P10 — Canvas node infrastructure</td><td><span class="dep-tag">P-PC.6</span></td><td style="font-size:11.5px;color:var(--t1)">Canvas node reuses the live polling subscription pattern from P10.1 and the harness node wrapper component</td></tr>
+  </tbody>
+  </table>
+</div>
+
+</div>
+
+<!-- INVARIANTS -->
+<div id="invariants" class="tab-content">
+
+<div class="card">
+  <div class="card-title">New invariants introduced in this phase</div>
+  <div class="card-body">This phase introduces four new invariants specific to process concepts. They are checked by the integration tests in P-PC.7 and must hold before this phase is declared complete. They do not replace any of the P0–P9 invariants, which continue to apply unchanged to concept-seeded runs.</div>
+</div>
+
+<div class="inv-list">
+  <div class="inv-item">
+    <strong>INV-PC-01 — Process concept is a strong prior, not a constraint <span class="inv-tag">P-PC.4 scope</span></strong>
+    <code>seed_task_graph()</code> pre-populates the task graph but does not lock it. The existing replanning machinery (<code>diagnose_and_replan()</code>, <code>rebuild_task_graph()</code>) must be able to add, modify, or remove tasks during the run without restriction. A verification failure during a concept-seeded run can and should cause the task graph to diverge from the concept's original step list. The concept provides the starting scaffold; the harness's reasoning and recovery layers own the graph from that point forward. Verified by P-PC.7.2.
+  </div>
+  <div class="inv-item">
+    <strong>INV-PC-02 — concept-seeded graph passes the same validate_task_graph() gate <span class="inv-tag">P-PC.4 scope</span></strong>
+    A concept-seeded task graph is not treated as pre-validated. After <code>seed_task_graph()</code> populates the graph, <code>validate_task_graph()</code> and <code>decomposition_gate()</code> run exactly as they would for a model-driven graph. A concept whose step structure is incompatible with the objective is caught and reported via the gate's GATHER_CLARIFICATION or ESCALATE response. <code>decomposition_gate()</code> is never bypassed for concept-seeded runs. Verified by P-PC.4 acceptance test 3.
+  </div>
+  <div class="inv-item">
+    <strong>INV-PC-03 — process_concept=None path is structurally unchanged <span class="inv-tag">P-PC.4 · P-PC.7 scope</span></strong>
+    When <code>initialize()</code> is called without a <code>process_concept</code> (or with <code>process_concept=None</code>), the resulting <code>HarnessRunState</code> must be structurally identical to a state produced by the pre-concept code. No new required fields, no changed defaults, no altered task graph initialization. The optional <code>process_concept_id</code> field on <code>HarnessRunState</code> is <code>None</code> and does not affect any downstream logic. This ensures that all 208 P0–P9 tests continue to pass without modification. Verified by P-PC.7.3 and P-PC.7.5.
+  </div>
+  <div class="inv-item">
+    <strong>INV-PC-04 — explicitly-specified missing concept is a hard error <span class="inv-tag">P-PC.5 scope</span></strong>
+    When <code>harness_meta.process_concept_id</code> is set in the FlowSpec but the named concept cannot be found in the registry, the run must fail with a <code>ProcessConceptNotFoundError</code> — it must not silently fall back to model-driven decomposition. An explicitly specified concept that is missing is a configuration error: the operator intended a specific guided run and silent fallback would produce an unexpectedly unguided run with no indication of the failure. The error response must include the missing concept ID. Verified by P-PC.5 acceptance test 3.
+  </div>
+</div>
+
+<div class="card" style="margin-top:.75rem">
+  <div class="card-title">P0–P9 invariants engaged in this phase (unchanged)</div>
+  <div class="card-body" style="font-size:12px;line-height:1.8">The following existing invariants apply to concept-seeded runs without modification:
+    <br><strong style="color:var(--t0)">INV-01 (observation/conclusion separation):</strong> Unchanged — no new evidence integration paths. The concept seeds the task graph, not the world model or evidence store.
+    <br><strong style="color:var(--t0)">INV-03 (generation_id double-increment):</strong> Unchanged — seeding happens before the first loop iteration; the double-increment per iteration is unaffected.
+    <br><strong style="color:var(--t0)">INV-06 (control_state as sole control input):</strong> Unchanged — the concept has no write path to control_state. Task selection from a concept-seeded graph still uses control_state exclusively for go/no-go decisions.
+    <br><strong style="color:var(--t0)">INV-10 (experience_store no-op when absent):</strong> Unchanged — warm_start() runs after seed_task_graph() with the same no-op contract when experience_store is unavailable.
+  </div>
+</div>
+
+</div>
+
+<!-- ALL TESTS -->
+<div id="tests" class="tab-content">
+
+<div class="card">
+  <div class="card-title">All 28 acceptance tests — <code>adapter/tests/test_harness_process_concepts.py</code></div>
+  <div class="card-body">All tests use in-memory fixtures — no live database or running adapter required. Run with <code>pytest adapter/tests/test_harness_process_concepts.py -v</code>. Run the full regression suite with <code>pytest adapter/tests/ -v -k harness</code> to confirm 208/208 P0–P9 tests still pass.</div>
+</div>
+
+<div class="section-label">P-PC.1 — ProcessConcept dataclasses (4 tests)</div>
+<div class="test-item">T01 · <code>from_dict()</code> raises <code>ProcessConceptValidationError</code> when a step's <code>depends_on</code> references a non-existent step ID — error message includes the missing ID</div>
+<div class="test-item">T02 · <code>validate()</code> detects a two-step cycle (A→B, B→A) and raises <code>ProcessConceptValidationError</code> with the cycle path in the message</div>
+<div class="test-item">T03 · <code>seed_task_graph()</code> namespaces all task IDs as <code>{concept_id}:{step_id}</code> — no task ID equals any raw step ID from the source concept</div>
+<div class="test-item">T04 · <code>seed_task_graph()</code> output passes <code>validate_task_graph()</code> without error for a well-formed 4-step linear concept</div>
+
+<div class="section-label">P-PC.2 — ProcessRegistry (4 tests)</div>
+<div class="test-item">T05 · <code>register()</code> raises <code>ProcessConceptNotFoundError</code> with the path in the message when the file does not exist on disk</div>
+<div class="test-item">T06 · <code>load()</code> on an unregistered concept_id raises <code>ProcessConceptNotFoundError</code> with the missing ID; a second call raises the same error without side effects</div>
+<div class="test-item">T07 · <code>scan_directory()</code> registers all valid JSON files in a temp directory and logs exactly one warning (without raising) for a malformed file — the other valid files are still registered</div>
+<div class="test-item">T08 · <code>list_available()</code> returns concept IDs in sorted alphabetical order; length equals the number of valid concept files registered</div>
+
+<div class="section-label">P-PC.3 — Bundled concept files (4 tests)</div>
+<div class="test-item">T09 · All 4 bundled concept files parse via <code>from_file()</code> without error; step counts are 6, 7, 5, 7 for debug_test_failure, implement_feature, code_review, refactor_module respectively</div>
+<div class="test-item">T10 · <code>implement_feature.json</code> encodes the parallel fan-out: <code>survey_codebase</code> and <code>design_interface</code> both depend on <code>read_requirements</code>; after <code>seed_task_graph()</code> the <code>implement</code> task depends on both namespaced IDs</div>
+<div class="test-item">T11 · <code>refactor_module.json</code> produces an <code>apply_refactor</code> task with <code>risk_level=HIGH</code> after <code>seed_task_graph()</code></div>
+<div class="test-item">T12 · JSON schema validation correctly rejects a concept file with <code>"risk_level": "CRITICAL"</code> — <code>ProcessConceptValidationError</code> is raised and its message references the invalid field value</div>
+
+<div class="section-label">P-PC.4 — loop.py initialize() integration (4 tests)</div>
+<div class="test-item">T13 · <code>initialize(process_concept=None)</code> produces a <code>HarnessRunState</code> with zero tasks in <code>task_graph</code> — identical in structure to all P0–P9 run initializations</div>
+<div class="test-item">T14 · <code>initialize()</code> with a 6-step concept produces a <code>HarnessRunState</code> with exactly 6 PENDING tasks and <code>process_concept_id</code> set to the concept's ID</div>
+<div class="test-item">T15 · <code>decomposition_gate()</code> is not bypassed: providing a concept whose steps are misaligned with the objective causes the gate to return GATHER_CLARIFICATION</div>
+<div class="test-item">T16 · <code>warm_start()</code> runs after seeding and updates <code>strategy_state.prior_strategy_weights</code> without clearing the seeded task_graph — task count remains 6 after warm_start completes</div>
+
+<div class="section-label">P-PC.5 — FlowSpec extension + run-start wiring (4 tests)</div>
+<div class="test-item">T17 · A flow spec with <code>harness_meta.process_concept_id = "debug_test_failure"</code> passes validate.py; a spec with <code>process_concept_id = ""</code> (empty string) fails with a message containing "non-empty"</div>
+<div class="test-item">T18 · Run start with a valid concept ID results in a <code>HarnessRunState</code> with <code>process_concept_id</code> set and <code>task_graph</code> containing the concept's step count</div>
+<div class="test-item">T19 · Run start with <code>process_concept_id = "nonexistent_concept"</code> returns a 400 response containing the missing ID and the phrase "not found in registry" — no run is started</div>
+<div class="test-item">T20 · <code>GET /concepts</code> returns all 4 bundled concepts after startup; each entry has the correct <code>step_count</code> matching the concept JSON file</div>
+
+<div class="section-label">P-PC.6 — Canvas process_concept node (4 tests)</div>
+<div class="test-item">T21 · Step rows in the <code>refactor_module</code> fixture render with correct risk badges: LOW steps show slate badges; the <code>apply_refactor</code> step shows a red HIGH badge</div>
+<div class="test-item">T22 · Dependency arrows render correctly for <code>implement_feature</code>: <code>survey_codebase</code> and <code>design_interface</code> both show a connector line from <code>read_requirements</code>; <code>implement</code> shows connector lines from both</div>
+<div class="test-item">T23 · Live run overlay: steps whose namespaced task IDs are COMPLETE show a green badge; PENDING steps show no status overlay — confirmed from a mixed-status fixture with 3 COMPLETE and 4 PENDING tasks</div>
+<div class="test-item">T24 · <code>compile_process_concept_node({"concept_id": "debug_test_failure", ...})</code> sets <code>harness_meta.process_concept_id = "debug_test_failure"</code> in the compiled FlowSpec and emits no standalone adapter function calls</div>
+
+<div class="section-label">P-PC.7 — Integration tests (4 tests)</div>
+<div class="test-item">T25 · Full path: <code>scan_directory() → load("debug_test_failure") → initialize(process_concept=concept)</code> produces a <code>HarnessRunState</code> with 6 PENDING tasks, all with IDs of the form <code>"debug_test_failure:{step_id}"</code></div>
+<div class="test-item">T26 · INV-PC-01: a replanning call during a <code>code_review</code>-seeded run adds a task not in the original concept; <code>len(task_graph.tasks) > 5</code> after the replan</div>
+<div class="test-item">T27 · INV-PC-03: <code>initialize(process_concept=None)</code> produces a <code>HarnessRunState</code> with zero tasks and <code>process_concept_id=None</code> — structurally identical to all pre-concept P0–P9 test fixtures</div>
+<div class="test-item">T28 · 208/208 P0–P9 acceptance tests pass after all process concepts changes land — <code>pytest adapter/tests/ -v -k harness</code> exits with code 0</div>
+
+<div class="card" style="margin-top:.75rem">
+  <div class="card-title">Running process concepts tests</div>
+  <div class="card-body">
+    Process concepts tests only: <code style="font-family:var(--font-mono);font-size:11.5px;background:var(--bg2);padding:3px 8px;border-radius:4px;display:inline-block">pytest adapter/tests/test_harness_process_concepts.py -v</code><br><br>
+    Full harness suite (P0–P9 regression check): <code style="font-family:var(--font-mono);font-size:11.5px;background:var(--bg2);padding:3px 8px;border-radius:4px;display:inline-block">pytest adapter/tests/ -v -k harness</code><br><br>
+    No database infrastructure is required for any test in this phase — all tests use in-memory sessions or mock fixtures from the P8 test infrastructure. Canvas component tests run via the existing canvas test runner. Target: 28 + 208 = 236 total harness tests passing before this phase closes.
+  </div>
+</div>
+
+</div>
+
+</div><!-- root -->
+
+<script>
+function showTab(id,btn){
+  document.querySelectorAll('.tab-content').forEach(x=>x.classList.remove('active'));
+  document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active'));
+  document.getElementById(id).classList.add('active');
+  btn.classList.add('active');
+}
+function toggleTask(id){
+  const body=document.getElementById('body-'+id);
+  body.classList.toggle('open');
+}
+['ppc1','ppc2','ppc3','ppc4','ppc5','ppc6','ppc7'].forEach(id=>{
+  const b=document.getElementById('body-'+id);
+  if(b) b.classList.add('open');
+});
+</script>
+</body>
+</html>

--- a/spec/schema.ts
+++ b/spec/schema.ts
@@ -842,9 +842,11 @@ export type FlowConfig = z.infer<typeof FlowConfig>
 // ---------------------------------------------------------------------------
 
 export const HarnessMeta = z.object({
-  harness_version: z.string().optional(),
-  phase:           z.string().optional(),
-  enabled:         z.boolean().default(false),
+  harness_version:    z.string().optional(),
+  phase:              z.string().optional(),
+  enabled:            z.boolean().default(false),
+  process_concept_id: z.string().optional()
+    .describe('ID of the process concept that seeds the task graph for this run. Must reference a registered concept. When absent the model performs its own decomposition.'),
 }).describe(
   'Marks a flow as harness-capable. When enabled is false (default), the adapter rejects harness node types. ' +
   'Set enabled: true only on flows that have been migrated and use harness nodes.'


### PR DESCRIPTION
## Summary

- **P-PC.1** — `ProcessConcept` and `ProcessConceptStep` dataclasses with `validate()`, `from_dict/to_dict`, `from_file()` (mtime-keyed cache), and `seed_task_graph()` (in-place, namespaced IDs)
- **P-PC.2** — `ProcessRegistry` with thread-safe `register/load/list_available/scan_directory`; `DEFAULT_REGISTRY` auto-scans `concepts/` at import; `ProcessConceptNotFoundError` / `ProcessConceptValidationError` defined in `process_concept.py`
- **P-PC.3** — Four bundled concept JSON files (5/6/6/5 steps): `debug_test_failure`, `implement_feature`, `code_review`, `refactor_module` + `concept_schema.json`
- **P-PC.4** — New `initialize_harness()` in `loop.py`; seeds task graph, validates, runs `decomposition_gate()`, returns result dict; `HarnessRunState` gains optional `process_concept_id` field
- **P-PC.5** — `validate.py` accepts `process_concept` node type and `process_concept_id` in `harness_meta`; `run_api.py` adds concept existence check (400 on missing) and `GET /run/concepts` endpoint
- **P-PC.6** — Backend only: `compile_process_concept_node` in `node_compilers.py`; frontend canvas node deferred to P11
- **P-PC.7** — 30 tests in `adapter/tests/test_harness_process_concepts.py` (28 named T01–T28 + 2 bonus)
- **Plan file** — `plan/phase_process_concepts_plan.html` updated to reflect as-built state with all divergences documented

## Test plan

- [ ] `pytest adapter/tests/test_harness_process_concepts.py -v` — 30 tests pass
- [ ] All 4 bundled concept files pass `validate()` (covered by `test_bundled_concepts_valid`)
- [ ] `DEFAULT_REGISTRY` populated with all 4 concept IDs after import (covered by `test_default_registry_populated`)
- [ ] `python -m py_compile` passes for all new harness modules

---
_Generated by [Claude Code](https://claude.ai/code/session_0137sM22EsaCa6bLpbtog5is)_