### PR TITLE
Adoption B1 fix: deploy-chat-ui via SSH deploy key

### DIFF
--- a/.github/workflows/deploy-chat-ui.yml
+++ b/.github/workflows/deploy-chat-ui.yml
@@ -5,9 +5,9 @@ name: Deploy chat-ui to /try
 # https://buildaharness.com/try. Bring-your-own-key only — the page keeps API keys
 # in the visitor's browser (localStorage), nothing is proxied server-side.
 #
-# Needs secrets.PAGES_DEPLOY_TOKEN: a token that can push to 3IVIS/buildaharness-pages
-# (a fine-grained PAT with Contents: read/write on that repo, or a classic PAT with
-# `repo`). Without it the deploy step fails fast with a clear message.
+# Needs secrets.PAGES_DEPLOY_KEY: the private half of an SSH deploy key with write
+# access on 3IVIS/buildaharness-pages (Settings → Deploy keys, "Allow write access").
+# Without it the deploy step fails fast with a clear message.
 
 on:
   push:
@@ -53,11 +53,11 @@ jobs:
           CHAT_UI_BASE: /try/
         run: npm run build --workspace=packages/chat-ui
 
-      - name: Check deploy token is present
+      - name: Check deploy key is present
         run: |
-          if [ -z "${{ secrets.PAGES_DEPLOY_TOKEN }}" ]; then
-            echo "❌  secrets.PAGES_DEPLOY_TOKEN is not set — cannot push to 3IVIS/buildaharness-pages."
-            echo "    Add a fine-grained PAT (Contents: read/write on buildaharness-pages) as that secret."
+          if [ -z "${{ secrets.PAGES_DEPLOY_KEY }}" ]; then
+            echo "❌  secrets.PAGES_DEPLOY_KEY is not set — cannot push to 3IVIS/buildaharness-pages."
+            echo "    Add the private half of a write-enabled SSH deploy key for that repo as this secret."
             exit 1
           fi
 
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 3IVIS/buildaharness-pages
-          token: ${{ secrets.PAGES_DEPLOY_TOKEN }}
+          ssh-key: ${{ secrets.PAGES_DEPLOY_KEY }}
           path: pages
 
       - name: Sync build into pages/try


### PR DESCRIPTION
## Why

`deploy-chat-ui.yml` (merged in #17) expects `secrets.PAGES_DEPLOY_TOKEN`, but that secret was never actually added to the repo — the workflow run on the #17 merge failed fast at the token check. A fine-grained PAT can't be created without the GitHub web UI.

## What

Switch the `buildaharness-pages` checkout + push from HTTPS token auth to an **SSH deploy key**:

- `actions/checkout` for the pages repo now uses `ssh-key: ${{ secrets.PAGES_DEPLOY_KEY }}`
- the pre-flight check looks for `PAGES_DEPLOY_KEY`
- header comment updated

The deploy key is a **write** key scoped to `3IVIS/buildaharness-pages` only — tighter than a classic `repo` PAT and not tied to any personal account. It's already registered on the pages repo (Settings → Deploy keys, "buildaharness-ci deploy (chat-ui /try)") and the private half is set as the `PAGES_DEPLOY_KEY` Actions secret on this repo.

## After merge

The `Deploy chat-ui to /try` workflow fires on the merge (it touches `.github/workflows/deploy-chat-ui.yml`) and should publish `/try/` to the pages repo for real. Then: A4 tags → pages-branch merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBiRcyjoTLvAvduYsbiZwx