### PR TITLE
Adoption A4 fix: npx @buildaharness/personal-assistant actually starts (0.2.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Version](https://img.shields.io/badge/version-v0.8.0-brightgreen.svg)](https://github.com/3IVIS/buildaharness/releases)
 [![Status](https://img.shields.io/badge/status-public%20alpha-orange.svg)](https://github.com/3IVIS/buildaharness)
-[![Tests](https://img.shields.io/badge/tests-2%2C915%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/tests-2%2C921%20passing-brightgreen.svg)](#)
 [![GitHub Stars](https://img.shields.io/github/stars/3IVIS/buildaharness?style=social)](https://github.com/3IVIS/buildaharness/stargazers)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Node.js](https://img.shields.io/badge/Node.js-18+-339933.svg?logo=node.js&logoColor=white)](https://nodejs.org/)

--- a/README_CN.md
+++ b/README_CN.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/许可证-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Version](https://img.shields.io/badge/版本-v0.8.0-brightgreen.svg)](https://github.com/3IVIS/buildaharness/releases)
 [![Status](https://img.shields.io/badge/状态-公开测试版-orange.svg)](https://github.com/3IVIS/buildaharness)
-[![Tests](https://img.shields.io/badge/测试-2%2C915%20通过-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/测试-2%2C921%20通过-brightgreen.svg)](#)
 [![GitHub Stars](https://img.shields.io/github/stars/3IVIS/buildaharness?style=social)](https://github.com/3IVIS/buildaharness/stargazers)
 [![PRs Welcome](https://img.shields.io/badge/欢迎-PR贡献-brightgreen.svg)](CONTRIBUTING.md)
 [![Node.js](https://img.shields.io/badge/Node.js-18+-339933.svg?logo=node.js&logoColor=white)](https://nodejs.org/)

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -8,9 +8,9 @@ not transcluded, since GitHub-rendered markdown has no include mechanism.
 
 | Metric | Count | Source |
 |---|---|---|
-| Frontend tests (vitest) | 1816 across 112 files | `npm test` (root — aggregates src/ and every packages/* workspace) |
+| Frontend tests (vitest) | 1822 across 113 files | `npm test` (root — aggregates src/ and every packages/* workspace) |
 | Adapter tests (pytest) | 1099 | `pytest adapter/tests/ -v` |
 | MAF adapter tests | 42 | `pytest adapter/tests/test_maf_adapter.py -v` |
-| Project-wide tests | 2,915 | pytest + vitest combined |
+| Project-wide tests | 2,921 | pytest + vitest combined |
 | Node types | 27 (14 execution + 13 harness) | `Node`/`HarnessNode` discriminated unions in `spec/schema.ts` |
 | Docker Compose services | 12 | `docker-compose.yml` top-level `services:` keys, excluding one-shot `restart: "no"` init jobs |

--- a/package-lock.json
+++ b/package-lock.json
@@ -10828,7 +10828,7 @@
     },
     "packages/personal-assistant": {
       "name": "@buildaharness/personal-assistant",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@buildaharness/harness": "^0.2.0",

--- a/packages/personal-assistant/package.json
+++ b/packages/personal-assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildaharness/personal-assistant",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An open-source AI chat assistant that runs the full 11-layer Build A Harness every turn — light for a fact lookup, and it stops for approval before it sends an email or runs a shell command. CLI, browser, and desktop.",
   "license": "Apache-2.0",
   "homepage": "https://buildaharness.com/personal-assistant",

--- a/packages/personal-assistant/src/cli-entry.test.ts
+++ b/packages/personal-assistant/src/cli-entry.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { realpathSync, mkdtempSync, writeFileSync, symlinkSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { entryArgMatchesModule } from './cli.js'
+
+/**
+ * Regression for the npx-launch bug: `isEntryModule()` compared a raw
+ * `pathToFileURL(process.argv[1])` against `import.meta.url`. Under `npx
+ * @buildaharness/personal-assistant` (and every other npm-bin path) argv[1] is
+ * the `node_modules/.bin/personal-assistant` symlink, so the two never matched
+ * and `main()` was skipped — the CLI exited 0 with no REPL.
+ */
+describe('entryArgMatchesModule', () => {
+  const moduleReal = join(tmpdir(), 'pa-fake', 'dist', 'cli.js')
+  const moduleHref = pathToFileURL(moduleReal).href
+
+  it('matches when argv[1] is the module file itself', () => {
+    expect(entryArgMatchesModule(moduleReal, moduleHref, (p) => p)).toBe(true)
+  })
+
+  it('matches when argv[1] is a symlink to the module (the npm-bin / npx case)', () => {
+    const binShim = join(tmpdir(), 'pa-fake', 'node_modules', '.bin', 'personal-assistant')
+    const resolveReal = (p: string) => (p === binShim ? moduleReal : p)
+    expect(entryArgMatchesModule(binShim, moduleHref, resolveReal)).toBe(true)
+  })
+
+  it('does not match a different file', () => {
+    const other = join(tmpdir(), 'pa-fake', 'dist', 'other.js')
+    expect(entryArgMatchesModule(other, moduleHref, (p) => p)).toBe(false)
+  })
+
+  it('returns false when argv[1] is undefined (imported as a library)', () => {
+    expect(entryArgMatchesModule(undefined, moduleHref)).toBe(false)
+  })
+
+  it('returns false instead of throwing when argv[1] cannot be resolved', () => {
+    expect(
+      entryArgMatchesModule('/no/such/path', moduleHref, () => {
+        throw new Error('ENOENT')
+      }),
+    ).toBe(false)
+  })
+
+  it('resolves a real on-disk symlink through the default realpathSync', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pa-entry-'))
+    try {
+      const real = join(dir, 'cli.js')
+      writeFileSync(real, '// fake cli\n')
+      const link = join(dir, 'bin-link')
+      symlinkSync(real, link)
+      const href = pathToFileURL(realpathSync(real)).href
+      expect(entryArgMatchesModule(link, href)).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/personal-assistant/src/cli.ts
+++ b/packages/personal-assistant/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { createInterface } from 'node:readline'
 import { writeFile } from 'node:fs/promises'
+import { realpathSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join, resolve as resolvePath } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -1114,9 +1115,33 @@ async function main(): Promise<void> {
   await runCli()
 }
 
+/**
+ * True when `entryArg` (a `process.argv[1]` value) refers to the same file as
+ * `moduleHref` (an `import.meta.url`).
+ *
+ * The naive check — `moduleHref === pathToFileURL(entryArg).href` — breaks
+ * whenever the script is launched through the npm bin: `npx
+ * @buildaharness/personal-assistant`, a global install, or any
+ * `node_modules/.bin` shim all pass a **symlink** to this file as
+ * `process.argv[1]`, while Node reports `import.meta.url` as the resolved real
+ * path. So resolve `entryArg` to its real path before comparing. `resolveReal`
+ * is injected for tests; it defaults to `fs.realpathSync`.
+ */
+export function entryArgMatchesModule(
+  entryArg: string | undefined,
+  moduleHref: string,
+  resolveReal: (p: string) => string = realpathSync,
+): boolean {
+  if (entryArg === undefined) return false
+  try {
+    return moduleHref === pathToFileURL(resolveReal(entryArg)).href
+  } catch {
+    return false
+  }
+}
+
 function isEntryModule(): boolean {
-  const entry = process.argv[1]
-  return entry !== undefined && import.meta.url === pathToFileURL(entry).href
+  return entryArgMatchesModule(process.argv[1], import.meta.url)
 }
 
 // Guarded so importing this module (e.g. from cli.test.ts, which drives runCli() directly

--- a/packages/personal-assistant/vite.config.lib.ts
+++ b/packages/personal-assistant/vite.config.lib.ts
@@ -21,7 +21,7 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['@buildaharness/harness', '@buildaharness/runtime', 'nodemailer', 'node:readline', 'node:process', 'node:fs/promises', 'node:os', 'node:path', 'node:child_process', 'node:url', 'node:dns/promises', 'node:crypto', 'node:net'],
+      external: ['@buildaharness/harness', '@buildaharness/runtime', 'nodemailer', 'node:readline', 'node:process', 'node:fs', 'node:fs/promises', 'node:os', 'node:path', 'node:child_process', 'node:url', 'node:dns/promises', 'node:crypto', 'node:net'],
     },
     minify: false,
     sourcemap: true,


### PR DESCRIPTION
## The bug

The published **0.2.0** CLI exits `0` with **no output** when launched the way the README and website tell users to — `npx @buildaharness/personal-assistant`, a global install, or any `node_modules/.bin` shim. The REPL never starts.

`isEntryModule()` compared `pathToFileURL(process.argv[1]).href` against `import.meta.url`. Through the npm bin, `process.argv[1]` is the `.bin/personal-assistant` **symlink**, while Node reports `import.meta.url` as the **resolved real path** — so they never match and `main()` is skipped. `node dist/cli.js` by path works, which is why the pre-publish tarball smoke tests never caught it.

## Fix

- `entryArgMatchesModule()` — pure, tested helper — resolves `argv[1]` through `fs.realpathSync` before comparing. `isEntryModule()` is now a one-line wrapper.
- `node:fs` added to the lib build's rollup `external` list (alongside the existing `node:fs/promises`) — otherwise vite tries to browser-bundle `realpathSync`.
- `cli-entry.test.ts` — pins the symlink case, undefined `argv[1]`, a mismatch, an unresolvable path, and a real on-disk symlink through the default `realpathSync`.
- Bump `@buildaharness/personal-assistant` `0.2.0` → `0.2.1`; regen stats.

The identical-looking check in `file-tools-mcp-server.mjs` is deliberately left alone — that server is only ever spawned as `node <absolute-real-path>` by `claude-cli-llm-client.ts`, never through a bin symlink.

## Verification

Packed the `0.2.1` tarball, installed into a clean dir, ran `./node_modules/.bin/personal-assistant` → Aielia REPL starts, `claude-cli` backend auto-detected. 972 PA tests green, typecheck clean, `gen-stats --check` clean.

## Follow-up

After merge: push `pa-v0.2.1` to publish the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPhfkc3DNV5zue5js9QpnY