### PR TITLE
harness D2 one-loop: wire oneLoopMode through the browser/desktop build

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Version](https://img.shields.io/badge/version-v0.8.0-brightgreen.svg)](https://github.com/3IVIS/buildaharness/releases)
 [![Status](https://img.shields.io/badge/status-public%20alpha-orange.svg)](https://github.com/3IVIS/buildaharness)
-[![Tests](https://img.shields.io/badge/tests-3%2C069%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/tests-3%2C083%20passing-brightgreen.svg)](#)
 [![GitHub Stars](https://img.shields.io/github/stars/3IVIS/buildaharness?style=social)](https://github.com/3IVIS/buildaharness/stargazers)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Node.js](https://img.shields.io/badge/Node.js-18+-339933.svg?logo=node.js&logoColor=white)](https://nodejs.org/)

--- a/README_CN.md
+++ b/README_CN.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/许可证-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Version](https://img.shields.io/badge/版本-v0.8.0-brightgreen.svg)](https://github.com/3IVIS/buildaharness/releases)
 [![Status](https://img.shields.io/badge/状态-公开测试版-orange.svg)](https://github.com/3IVIS/buildaharness)
-[![Tests](https://img.shields.io/badge/测试-3%2C069%20通过-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/测试-3%2C083%20通过-brightgreen.svg)](#)
 [![GitHub Stars](https://img.shields.io/github/stars/3IVIS/buildaharness?style=social)](https://github.com/3IVIS/buildaharness/stargazers)
 [![PRs Welcome](https://img.shields.io/badge/欢迎-PR贡献-brightgreen.svg)](CONTRIBUTING.md)
 [![Node.js](https://img.shields.io/badge/Node.js-18+-339933.svg?logo=node.js&logoColor=white)](https://nodejs.org/)

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -8,9 +8,9 @@ not transcluded, since GitHub-rendered markdown has no include mechanism.
 
 | Metric | Count | Source |
 |---|---|---|
-| Frontend tests (vitest) | 1928 across 126 files | `npm test` (root — aggregates src/ and every packages/* workspace) |
+| Frontend tests (vitest) | 1942 across 127 files | `npm test` (root — aggregates src/ and every packages/* workspace) |
 | Adapter tests (pytest) | 1141 | `pytest adapter/tests/ -v` |
 | MAF adapter tests | 42 | `pytest adapter/tests/test_maf_adapter.py -v` |
-| Project-wide tests | 3,069 | pytest + vitest combined |
+| Project-wide tests | 3,083 | pytest + vitest combined |
 | Node types | 27 (14 execution + 13 harness) | `Node`/`HarnessNode` discriminated unions in `spec/schema.ts` |
 | Docker Compose services | 12 | `docker-compose.yml` top-level `services:` keys, excluding one-shot `restart: "no"` init jobs |

--- a/packages/chat-ui/src/App.test.tsx
+++ b/packages/chat-ui/src/App.test.tsx
@@ -405,6 +405,30 @@ describe('App', () => {
     })
   })
 
+  describe('oneLoopMode wiring (R5 — browser/desktop counterpart of the CLI\'s ASSISTANT_ONE_LOOP)', () => {
+    function seedConfig(patch: Record<string, unknown>): void {
+      localStorage.setItem('buildaharness.personal-assistant.config', JSON.stringify(patch))
+    }
+
+    function lastCreateOptions(): { oneLoopMode?: string } {
+      const calls = (PersonalAssistant.create as unknown as { mock: { calls: Array<[{ oneLoopMode?: string }]> } }).mock.calls
+      return calls.at(-1)?.[0] ?? {}
+    }
+
+    it('passes no oneLoopMode by default (PersonalAssistant falls back to DEFAULT_ONE_LOOP_MODE)', async () => {
+      render(<App />)
+      await waitFor(() => expect(PersonalAssistant.create).toHaveBeenCalled())
+      expect(lastCreateOptions().oneLoopMode).toBeUndefined()
+    })
+
+    it('threads a persisted oneLoopMode through to PersonalAssistant.create', async () => {
+      seedConfig({ oneLoopMode: 'enabled' })
+      render(<App />)
+      await waitFor(() => expect(PersonalAssistant.create).toHaveBeenCalled())
+      expect(lastCreateOptions().oneLoopMode).toBe('enabled')
+    })
+  })
+
   describe('/search UI (T6)', () => {
     it('opens the Search panel via the header button and renders results for a query with matches', async () => {
       const user = userEvent.setup()

--- a/packages/chat-ui/src/App.tsx
+++ b/packages/chat-ui/src/App.tsx
@@ -221,6 +221,10 @@ async function createTauriBackedAssistant(config: AssistantConfig): Promise<Pers
       ? { backend: workspaceBackend, workspaceRoot, timeoutMs: config.shellTimeoutMs, executeCommand: tauriExecuteShellCommand }
       : undefined,
     dangerouslySkipPermissions: config.dangerouslySkipPermissions,
+    // R5 of plans/harness_d2_one_loop_rewire_plan.html — resolved through the same AssistantConfig
+    // seam the CLI uses (here from the build-time VITE_ASSISTANT_ONE_LOOP via browser-config.ts, or
+    // a persisted oneLoopMode). Undefined → PersonalAssistant falls back to DEFAULT_ONE_LOOP_MODE.
+    oneLoopMode: config.oneLoopMode,
     onDebugLog: debugLog,
   })
 }
@@ -235,6 +239,9 @@ async function buildAssistant(config: AssistantConfig): Promise<PersonalAssistan
     // since it also affects the message-level risk gate, independent of file/shell tools.
     webTools: config.enableWeb ? await createWebTools(config, false) : undefined,
     dangerouslySkipPermissions: config.dangerouslySkipPermissions,
+    // R5 of plans/harness_d2_one_loop_rewire_plan.html — same AssistantConfig seam as the desktop
+    // path above and the CLI. Undefined → PersonalAssistant falls back to DEFAULT_ONE_LOOP_MODE.
+    oneLoopMode: config.oneLoopMode,
     onDebugLog: debugLog,
   })
 }

--- a/packages/chat-ui/src/browser-config.test.ts
+++ b/packages/chat-ui/src/browser-config.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest'
+import { envOverridesFromImportMetaEnv, ENV_VAR_FOR_CONFIG_KEY } from './browser-config'
+
+/** A minimal ImportMetaEnv stand-in — the real one has an index signature, so this is enough. */
+function env(overrides: Record<string, string>): ImportMetaEnv {
+  return { ...overrides } as unknown as ImportMetaEnv
+}
+
+describe('envOverridesFromImportMetaEnv', () => {
+  it('returns {} when no VITE_ASSISTANT_* vars are set', () => {
+    expect(envOverridesFromImportMetaEnv(env({}))).toEqual({})
+  })
+
+  it('only maps a key when its build-time var is actually non-empty', () => {
+    expect(envOverridesFromImportMetaEnv(env({ VITE_ASSISTANT_PROXY_URL: '' }))).toEqual({})
+    expect(envOverridesFromImportMetaEnv(env({ VITE_ASSISTANT_PROXY_URL: 'https://proxy.example' }))).toEqual({
+      proxyUrl: 'https://proxy.example',
+    })
+  })
+
+  it('reads the proxy URL / token / model vars', () => {
+    expect(
+      envOverridesFromImportMetaEnv(
+        env({
+          VITE_ASSISTANT_PROXY_URL: 'https://proxy.example',
+          VITE_ASSISTANT_PROXY_TOKEN: 'tok',
+          VITE_ASSISTANT_MODEL: 'claude-sonnet-5',
+        }),
+      ),
+    ).toEqual({ proxyUrl: 'https://proxy.example', authToken: 'tok', model: 'claude-sonnet-5' })
+  })
+
+  it('resolves VITE_ASSISTANT_ONE_LOOP into oneLoopMode', () => {
+    expect(envOverridesFromImportMetaEnv(env({ VITE_ASSISTANT_ONE_LOOP: 'enabled' }))).toEqual({ oneLoopMode: 'enabled' })
+    expect(envOverridesFromImportMetaEnv(env({ VITE_ASSISTANT_ONE_LOOP: 'disabled' }))).toEqual({ oneLoopMode: 'disabled' })
+  })
+
+  it('an unset or empty VITE_ASSISTANT_ONE_LOOP leaves oneLoopMode absent (PersonalAssistant owns the default)', () => {
+    expect(envOverridesFromImportMetaEnv(env({}))).not.toHaveProperty('oneLoopMode')
+    expect(envOverridesFromImportMetaEnv(env({ VITE_ASSISTANT_ONE_LOOP: '' }))).not.toHaveProperty('oneLoopMode')
+  })
+
+  it('a typo\'d VITE_ASSISTANT_ONE_LOOP warns and falls back to "disabled"', () => {
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(envOverridesFromImportMetaEnv(env({ VITE_ASSISTANT_ONE_LOOP: 'on' }))).toEqual({ oneLoopMode: 'disabled' })
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0][0]).toContain('VITE_ASSISTANT_ONE_LOOP')
+    warn.mockRestore()
+  })
+
+  it('advertises VITE_ASSISTANT_ONE_LOOP as the pinning var for oneLoopMode', () => {
+    expect(ENV_VAR_FOR_CONFIG_KEY.oneLoopMode).toBe('VITE_ASSISTANT_ONE_LOOP')
+  })
+})

--- a/packages/chat-ui/src/browser-config.ts
+++ b/packages/chat-ui/src/browser-config.ts
@@ -1,4 +1,5 @@
 import type { AssistantConfig } from '@buildaharness/personal-assistant'
+import { normalizeOneLoopMode } from '@buildaharness/personal-assistant'
 
 /**
  * Browser-side companion to personal-assistant's cli-config.ts — same idea (env-var-name map
@@ -12,6 +13,7 @@ export const ENV_VAR_FOR_CONFIG_KEY: Partial<Record<keyof AssistantConfig, strin
   proxyUrl: 'VITE_ASSISTANT_PROXY_URL',
   authToken: 'VITE_ASSISTANT_PROXY_TOKEN',
   model: 'VITE_ASSISTANT_MODEL',
+  oneLoopMode: 'VITE_ASSISTANT_ONE_LOOP',
 }
 
 /**
@@ -25,5 +27,9 @@ export function envOverridesFromImportMetaEnv(env: ImportMetaEnv): Partial<Assis
   if (env.VITE_ASSISTANT_PROXY_URL) overrides.proxyUrl = env.VITE_ASSISTANT_PROXY_URL
   if (env.VITE_ASSISTANT_PROXY_TOKEN) overrides.authToken = env.VITE_ASSISTANT_PROXY_TOKEN
   if (env.VITE_ASSISTANT_MODEL) overrides.model = env.VITE_ASSISTANT_MODEL
+  // R5 of plans/harness_d2_one_loop_rewire_plan.html — the browser/desktop counterpart of the
+  // CLI's ASSISTANT_ONE_LOOP. normalizeOneLoopMode warns-and-defaults on a typo, so a build that
+  // sets this at all always resolves to a concrete 'enabled'/'disabled'.
+  if (env.VITE_ASSISTANT_ONE_LOOP) overrides.oneLoopMode = normalizeOneLoopMode(env.VITE_ASSISTANT_ONE_LOOP, 'VITE_ASSISTANT_ONE_LOOP')
   return overrides
 }

--- a/packages/personal-assistant/src/cli-config.test.ts
+++ b/packages/personal-assistant/src/cli-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { DEFAULT_CONFIG } from './config.js'
 import {
   isConfigKey,
@@ -64,6 +64,15 @@ describe('envOverridesFromProcessEnv', () => {
     expect(envOverridesFromProcessEnv({ ASSISTANT_SESSION_COST_LIMIT_USD: '5.5' })).toEqual({ sessionCostLimitUsd: 5.5 })
     expect(envOverridesFromProcessEnv({ ASSISTANT_SESSION_CALL_LIMIT: '50' })).toEqual({ sessionCallLimit: 50 })
   })
+
+  it('resolves ASSISTANT_ONE_LOOP into oneLoopMode, defaulting a typo to "disabled"', () => {
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(envOverridesFromProcessEnv({ ASSISTANT_ONE_LOOP: 'enabled' })).toEqual({ oneLoopMode: 'enabled' })
+    expect(envOverridesFromProcessEnv({ ASSISTANT_ONE_LOOP: 'disabled' })).toEqual({ oneLoopMode: 'disabled' })
+    expect(envOverridesFromProcessEnv({ ASSISTANT_ONE_LOOP: 'on' })).toEqual({ oneLoopMode: 'disabled' })
+    expect(warn).toHaveBeenCalledTimes(1)
+    warn.mockRestore()
+  })
 })
 
 describe('parseConfigValue', () => {
@@ -94,6 +103,12 @@ describe('parseConfigValue', () => {
   it('accepts a valid searchBackend/llmBackend', () => {
     expect(parseConfigValue('searchBackend', 'brave')).toBe('brave')
     expect(parseConfigValue('llmBackend', 'claude-cli')).toBe('claude-cli')
+  })
+
+  it('accepts "enabled"/"disabled" for oneLoopMode and rejects anything else', () => {
+    expect(parseConfigValue('oneLoopMode', 'enabled')).toBe('enabled')
+    expect(parseConfigValue('oneLoopMode', 'disabled')).toBe('disabled')
+    expect(() => parseConfigValue('oneLoopMode', 'on')).toThrow(ConfigValueParseError)
   })
 
   it.each(['anthropic', 'openai', 'openrouter'] as const)('accepts llmBackend "%s"', (backend) => {

--- a/packages/personal-assistant/src/cli-config.ts
+++ b/packages/personal-assistant/src/cli-config.ts
@@ -1,5 +1,6 @@
 import type { AssistantConfig } from './config.js'
 import { CONFIG_KEYS } from './config.js'
+import { resolveOneLoopMode } from './one-loop-flag.js'
 
 /**
  * Pure logic backing cli.ts's /config command family — split out so it's unit-testable in
@@ -38,6 +39,7 @@ export const ENV_VAR_FOR_CONFIG_KEY: Partial<Record<keyof AssistantConfig, strin
   dangerouslySkipPermissions: 'ASSISTANT_DANGEROUSLY_SKIP_PERMISSIONS',
   sessionCostLimitUsd: 'ASSISTANT_SESSION_COST_LIMIT_USD',
   sessionCallLimit: 'ASSISTANT_SESSION_CALL_LIMIT',
+  oneLoopMode: 'ASSISTANT_ONE_LOOP',
 }
 
 export function isConfigKey(key: string): key is keyof AssistantConfig {
@@ -97,6 +99,9 @@ export function envOverridesFromProcessEnv(env: NodeJS.ProcessEnv): Partial<Assi
   if (env.ASSISTANT_DANGEROUSLY_SKIP_PERMISSIONS !== undefined) overrides.dangerouslySkipPermissions = env.ASSISTANT_DANGEROUSLY_SKIP_PERMISSIONS === '1'
   if (env.ASSISTANT_SESSION_COST_LIMIT_USD !== undefined) overrides.sessionCostLimitUsd = Number(env.ASSISTANT_SESSION_COST_LIMIT_USD)
   if (env.ASSISTANT_SESSION_CALL_LIMIT !== undefined) overrides.sessionCallLimit = Number(env.ASSISTANT_SESSION_CALL_LIMIT)
+  // resolveOneLoopMode already warns-and-defaults on an unrecognized value, so an explicit
+  // ASSISTANT_ONE_LOOP always resolves to a concrete 'enabled'/'disabled' override here.
+  if (env.ASSISTANT_ONE_LOOP !== undefined) overrides.oneLoopMode = resolveOneLoopMode(env)
   return overrides
 }
 
@@ -144,6 +149,9 @@ export function parseConfigValue(key: keyof AssistantConfig, raw: string): unkno
       return raw
     case 'searchBackend':
       if (raw !== 'ddg' && raw !== 'brave') throw new ConfigValueParseError('searchBackend must be "ddg" or "brave"')
+      return raw
+    case 'oneLoopMode':
+      if (raw !== 'enabled' && raw !== 'disabled') throw new ConfigValueParseError('oneLoopMode must be "enabled" or "disabled"')
       return raw
     default:
       return raw

--- a/packages/personal-assistant/src/cli.ts
+++ b/packages/personal-assistant/src/cli.ts
@@ -40,7 +40,6 @@ import { estimateCostUsd } from './model-pricing.js'
 import { formatSpendCapStatus } from './spend-cap.js'
 import { checkProxyHealth, checkClaudeCli, checkWorkspaceRoot, checkDataDirWritable } from './doctor-checks.js'
 import { resolveNonInteractiveApprovalMode, type NonInteractiveApprovalMode } from './non-interactive-mode.js'
-import { resolveOneLoopMode } from './one-loop-flag.js'
 import { maybeRunFirstRunSetup } from './first-run.js'
 
 const defaultDataDir = join(homedir(), '.buildaharness', 'personal-assistant')
@@ -175,7 +174,11 @@ async function buildAssistant(config: AssistantConfig, { backend, dataDir, remin
       config.sessionCostLimitUsd !== undefined || config.sessionCallLimit !== undefined
         ? { sessionCostLimitUsd: config.sessionCostLimitUsd, sessionCallLimit: config.sessionCallLimit }
         : undefined,
-    oneLoopMode: resolveOneLoopMode(process.env),
+    // Resolved through the shared config seam (cli-config.ts's envOverridesFromProcessEnv reads
+    // ASSISTANT_ONE_LOOP into config.oneLoopMode; /config set oneLoopMode persists it) so the CLI,
+    // chat-ui, and the Tauri desktop build all decide this the same way. Undefined here means
+    // PersonalAssistant falls back to DEFAULT_ONE_LOOP_MODE.
+    oneLoopMode: config.oneLoopMode,
   })
 }
 

--- a/packages/personal-assistant/src/config.ts
+++ b/packages/personal-assistant/src/config.ts
@@ -6,6 +6,8 @@
  * applies one shared precedence rule so all three surfaces agree on what a given set of inputs means.
  */
 
+import type { OneLoopMode } from './one-loop-flag.js'
+
 export interface AssistantConfig {
   llmBackend: 'proxy' | 'claude-cli' | 'anthropic' | 'openai' | 'openrouter'
   proxyUrl: string
@@ -82,6 +84,19 @@ export interface AssistantConfig {
   sessionCostLimitUsd?: number
   /** Secondary ceiling on completed turns this session — see SpendCapConfig's doc comment in spend-cap.ts for why this counts turns, not raw internal LLM calls. */
   sessionCallLimit?: number
+  /**
+   * R5 of plans/harness_d2_one_loop_rewire_plan.html — the rollout flag for the harness-driven
+   * one-loop proposer (see one-loop-flag.ts's doc comment for the full rationale). Undefined (the
+   * default, for the whole rollout window) means PersonalAssistant falls back to
+   * DEFAULT_ONE_LOOP_MODE ('disabled') — today's behavior, byte-for-byte. This is the shared
+   * config seam every surface reads it through: the CLI resolves it from `ASSISTANT_ONE_LOOP`
+   * (cli-config.ts's envOverridesFromProcessEnv), chat-ui and the Tauri desktop build from the
+   * build-time `VITE_ASSISTANT_ONE_LOOP` (browser-config.ts's envOverridesFromImportMetaEnv), and
+   * all three from a persisted `oneLoopMode` if one has been set. Kept out of DEFAULT_CONFIG so an
+   * unset value stays undefined and PersonalAssistant owns the default, matching every other
+   * optional field here.
+   */
+  oneLoopMode?: OneLoopMode
 }
 
 /** Every AssistantConfig key, in the order every surface's settings UI/listing renders them. */
@@ -109,6 +124,7 @@ export const CONFIG_KEYS: readonly (keyof AssistantConfig)[] = [
   'dangerouslySkipPermissions',
   'sessionCostLimitUsd',
   'sessionCallLimit',
+  'oneLoopMode',
 ]
 
 /** Matches today's actual hardcoded defaults (proxy backend, ddg search, web/shell off) — this plan changes nothing for a caller that never touches config. */

--- a/packages/personal-assistant/src/index.ts
+++ b/packages/personal-assistant/src/index.ts
@@ -75,6 +75,8 @@ export {
 export type { PlanRecord, PlanTaskRecord, PlanPosition } from './plan-store.js'
 export { resolveConfig, validateConfig, ConfigValidationError, DEFAULT_CONFIG, CONFIG_KEYS } from './config.js'
 export type { AssistantConfig, ConfigStore, ResolvedConfig } from './config.js'
+export { resolveOneLoopMode, normalizeOneLoopMode, DEFAULT_ONE_LOOP_MODE } from './one-loop-flag.js'
+export type { OneLoopMode } from './one-loop-flag.js'
 // Pure, browser-safe formatters — deliberately NOT cli-config.ts/cli-session.ts's env-var-specific
 // exports (formatHelp, formatStatus, CLI_COMMANDS_HELP), which are CLI-syntax-specific
 // (e.g. "/model [name]") and have no GUI equivalent. These are plain data-in/text-out

--- a/packages/personal-assistant/src/one-loop-flag.test.ts
+++ b/packages/personal-assistant/src/one-loop-flag.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { DEFAULT_ONE_LOOP_MODE, resolveOneLoopMode } from './one-loop-flag.js'
+import { DEFAULT_ONE_LOOP_MODE, resolveOneLoopMode, normalizeOneLoopMode } from './one-loop-flag.js'
 
 describe('resolveOneLoopMode', () => {
   afterEach(() => {
@@ -24,5 +24,28 @@ describe('resolveOneLoopMode', () => {
     expect(resolveOneLoopMode({ ASSISTANT_ONE_LOOP: 'yes-please' })).toBe('disabled')
     expect(spy).toHaveBeenCalledTimes(1)
     expect(spy.mock.calls[0][0]).toContain('ASSISTANT_ONE_LOOP')
+  })
+})
+
+describe('normalizeOneLoopMode', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('treats undefined and empty string as the default (a Vite var defined but empty)', () => {
+    expect(normalizeOneLoopMode(undefined)).toBe('disabled')
+    expect(normalizeOneLoopMode('')).toBe('disabled')
+  })
+
+  it('passes "enabled"/"disabled" through', () => {
+    expect(normalizeOneLoopMode('enabled')).toBe('enabled')
+    expect(normalizeOneLoopMode('disabled')).toBe('disabled')
+  })
+
+  it('warns with the caller-supplied var name on a typo and falls back to the default', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(normalizeOneLoopMode('on', 'VITE_ASSISTANT_ONE_LOOP')).toBe('disabled')
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0][0]).toContain('VITE_ASSISTANT_ONE_LOOP')
   })
 })

--- a/packages/personal-assistant/src/one-loop-flag.ts
+++ b/packages/personal-assistant/src/one-loop-flag.ts
@@ -24,10 +24,22 @@ export type OneLoopMode = 'enabled' | 'disabled'
 
 export const DEFAULT_ONE_LOOP_MODE: OneLoopMode = 'disabled'
 
-export function resolveOneLoopMode(env: NodeJS.ProcessEnv): OneLoopMode {
-  const raw = env.ASSISTANT_ONE_LOOP
-  if (raw === undefined) return DEFAULT_ONE_LOOP_MODE
+/**
+ * Value-level resolver, shared by every surface: `resolveOneLoopMode` (CLI, reads
+ * `process.env.ASSISTANT_ONE_LOOP`) and chat-ui's `envOverridesFromImportMetaEnv` (browser build,
+ * reads Vite's `import.meta.env.VITE_ASSISTANT_ONE_LOOP`, which has no `process` to hand a
+ * `NodeJS.ProcessEnv` to). An unset or empty value falls back to the default silently; an
+ * unrecognized non-empty value falls back with a startup warning naming `varName`, the same
+ * typo-tolerance-with-a-warning convention resolveControlPlaneMode/resolveNonInteractiveApprovalMode
+ * use, since a silently-misread flag here is safety-relevant.
+ */
+export function normalizeOneLoopMode(raw: string | undefined, varName = 'ASSISTANT_ONE_LOOP'): OneLoopMode {
+  if (raw === undefined || raw === '') return DEFAULT_ONE_LOOP_MODE
   if (raw === 'enabled' || raw === 'disabled') return raw
-  console.error(`[warning] ASSISTANT_ONE_LOOP="${raw}" is not "enabled" or "disabled" — using the default (${DEFAULT_ONE_LOOP_MODE}).`)
+  console.error(`[warning] ${varName}="${raw}" is not "enabled" or "disabled" — using the default (${DEFAULT_ONE_LOOP_MODE}).`)
   return DEFAULT_ONE_LOOP_MODE
+}
+
+export function resolveOneLoopMode(env: NodeJS.ProcessEnv): OneLoopMode {
+  return normalizeOneLoopMode(env.ASSISTANT_ONE_LOOP)
 }


### PR DESCRIPTION
Closes item (1) of `plans/harness_d2_one_loop_rewire_plan.html`'s R5 "what's left" list: chat-ui and the Tauri desktop build never passed `oneLoopMode`, so they fell through to `DEFAULT_ONE_LOOP_MODE` regardless of any build-time var, and `cli.ts`'s `resolveOneLoopMode(process.env)` fix couldn't be copied (a browser bundle has no `process.env`).

## Change

All three surfaces now resolve `oneLoopMode` through one `AssistantConfig` seam:

- **`one-loop-flag.ts`** — extract `normalizeOneLoopMode(raw, varName?)`, a value-level resolver shared by `resolveOneLoopMode` (CLI, `ASSISTANT_ONE_LOOP`) and the browser (`VITE_ASSISTANT_ONE_LOOP`). Unset/empty → default; unrecognized → default + a warning naming the var.
- **`config.ts`** — `oneLoopMode?: OneLoopMode` added to `AssistantConfig` + `CONFIG_KEYS`; kept out of `DEFAULT_CONFIG` so unset stays `undefined` and `PersonalAssistant` owns the default.
- **`cli-config.ts`** — `ASSISTANT_ONE_LOOP` → `oneLoopMode` env override; `/config` listing + `/config set oneLoopMode` support.
- **`cli.ts`** — passes `config.oneLoopMode` (one resolution path for every surface).
- **`browser-config.ts`** — `VITE_ASSISTANT_ONE_LOOP` → `oneLoopMode` build-time override.
- **`App.tsx`** — `oneLoopMode: config.oneLoopMode` on both `PersonalAssistant.create()` sites (desktop + plain browser).
- **`index.ts`** — exports for chat-ui.

Precedence unchanged (`resolveConfig`): build-time var > persisted > `'disabled'` default. **Feature stays off by default.**

## Tests

- `one-loop-flag.test.ts` +3, `cli-config.test.ts` +2, **new `browser-config.test.ts`** (7 — module was untested), `App.test.tsx` +2
- Full suites green: personal-assistant 1052, chat-ui 106; typechecks + builds clean; stats regenerated

## Next (still R5, not in this PR)

Live-verify the chat-ui/desktop surface with the flag on, then flip `DEFAULT_ONE_LOOP_MODE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aFeKi9N5yRwPbbKmv14bS