### PR TITLE
harness D2 one-loop: real turn-scoped ControlState for both harness-driven proposers (R4 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Version](https://img.shields.io/badge/version-v0.8.0-brightgreen.svg)](https://github.com/3IVIS/buildaharness/releases)
 [![Status](https://img.shields.io/badge/status-public%20alpha-orange.svg)](https://github.com/3IVIS/buildaharness)
-[![Tests](https://img.shields.io/badge/tests-3%2C083%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/tests-3%2C084%20passing-brightgreen.svg)](#)
 [![GitHub Stars](https://img.shields.io/github/stars/3IVIS/buildaharness?style=social)](https://github.com/3IVIS/buildaharness/stargazers)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Node.js](https://img.shields.io/badge/Node.js-18+-339933.svg?logo=node.js&logoColor=white)](https://nodejs.org/)

--- a/README_CN.md
+++ b/README_CN.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/许可证-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Version](https://img.shields.io/badge/版本-v0.8.0-brightgreen.svg)](https://github.com/3IVIS/buildaharness/releases)
 [![Status](https://img.shields.io/badge/状态-公开测试版-orange.svg)](https://github.com/3IVIS/buildaharness)
-[![Tests](https://img.shields.io/badge/测试-3%2C083%20通过-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/测试-3%2C084%20通过-brightgreen.svg)](#)
 [![GitHub Stars](https://img.shields.io/github/stars/3IVIS/buildaharness?style=social)](https://github.com/3IVIS/buildaharness/stargazers)
 [![PRs Welcome](https://img.shields.io/badge/欢迎-PR贡献-brightgreen.svg)](CONTRIBUTING.md)
 [![Node.js](https://img.shields.io/badge/Node.js-18+-339933.svg?logo=node.js&logoColor=white)](https://nodejs.org/)

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -8,9 +8,9 @@ not transcluded, since GitHub-rendered markdown has no include mechanism.
 
 | Metric | Count | Source |
 |---|---|---|
-| Frontend tests (vitest) | 1942 across 127 files | `npm test` (root — aggregates src/ and every packages/* workspace) |
+| Frontend tests (vitest) | 1943 across 127 files | `npm test` (root — aggregates src/ and every packages/* workspace) |
 | Adapter tests (pytest) | 1141 | `pytest adapter/tests/ -v` |
 | MAF adapter tests | 42 | `pytest adapter/tests/test_maf_adapter.py -v` |
-| Project-wide tests | 3,083 | pytest + vitest combined |
+| Project-wide tests | 3,084 | pytest + vitest combined |
 | Node types | 27 (14 execution + 13 harness) | `Node`/`HarnessNode` discriminated unions in `spec/schema.ts` |
 | Docker Compose services | 12 | `docker-compose.yml` top-level `services:` keys, excluding one-shot `restart: "no"` init jobs |

--- a/packages/personal-assistant/src/agent-loop.ts
+++ b/packages/personal-assistant/src/agent-loop.ts
@@ -251,16 +251,18 @@ export class AgentLoop {
    * step, or a thrown OneLoopPause for `needs_approval`/`escalated` — never a thrown plain Error,
    * so execute() never misclassifies this as a tool failure.
    *
-   * `toolCtx.controlState`, when the harness has one resolved (see execute.ts's ToolExecutorContext
-   * doc comment), is folded in as this step's ControlState for tool-policy.ts's evaluateToolPolicy
-   * — the harness's own live per-iteration ControlState, not a second parallel structure — by
-   * wrapping it in a `{ controlState }` shape matching the one field runToolIterationStep's
-   * `controlPlaneState` parameter actually reads for the gate check. Recording each dispatched
-   * tool call's outcome back into a live ControlState the *next* iteration's actionGate can react
-   * to is real, buildable follow-up (would need worldModel/evidenceStore/diagnostics/
-   * failureDiagnostics from the same ToolExecutorContext threaded into recordToolOutcome) —
-   * deliberately not done here to keep this phase to the proposer + translation it was scoped for;
-   * flagged for R3/R4 to pick up if the validation matrix shows it's needed sooner.
+   * Control-plane state: the proposer holds one real, turn-scoped `TurnControlPlaneState`
+   * (`createControlPlaneState`, the exact object the flag-OFF flat path threads through
+   * `runToolLoop`) for its whole lifetime — so `runToolIterationStep`'s `recordToolOutcome` has
+   * real evidence/worldModel/diagnostics/failureDiagnostics stores to write each dispatched call's
+   * outcome into, and same-turn tool-failure-pattern gating behaves identically to flag-OFF. On
+   * top of that, the harness's own live per-iteration `toolCtx.controlState` is pinned onto that
+   * state at the start of every iteration as the gate's floor (D2's "one composition, not two"
+   * intent): a harness DENY / HUMAN_REQUIRED escalation is honored by `checkToolPolicy` before the
+   * iteration's first call executes. `recordToolOutcome` re-resolves `.controlState` from the
+   * turn-local stores after each recorded outcome — that only ever escalates further (8+ same-turn
+   * failures) and `evaluateToolPolicy` ignores `execution_mode`, so it never downgrades a harness
+   * escalation that would have mattered.
    */
   createHarnessProposer(input: {
     messages: ChatMessage[]
@@ -276,6 +278,10 @@ export class AgentLoop {
   }): (toolCtx: ToolExecutorContext) => Promise<unknown> {
     let dispatchedAnyToolCall = false
     let iteration = 0
+    // One real, turn-scoped live ControlState for the whole proposer (= the whole turn) — see this
+    // method's doc comment. recordToolOutcome dereferences state.evidenceStore, so this must be a
+    // real createControlPlaneState() object, never a synthetic { controlState }-only wrapper.
+    const controlPlaneState = this.createControlPlaneState()
 
     return async (toolCtx: ToolExecutorContext): Promise<unknown> => {
       if (iteration >= input.maxIterations) {
@@ -283,9 +289,10 @@ export class AgentLoop {
       }
       iteration++
 
-      const controlPlaneState = toolCtx.controlState
-        ? ({ controlState: toolCtx.controlState } as TurnControlPlaneState)
-        : undefined
+      // Pin the harness's own live per-iteration ControlState on as the gate floor for this
+      // iteration (see doc comment); recordToolOutcome re-resolves it from the turn-local stores
+      // after each dispatched call, which only escalates further.
+      if (toolCtx.controlState) controlPlaneState.controlState = toolCtx.controlState
 
       const step = await this.runToolIterationStep(
         input.messages, input.tools, input.sessionId, input.userMessage, input.sources, dispatchedAnyToolCall,
@@ -393,24 +400,17 @@ export class AgentLoop {
     let notAttempted: string[] = []
     let projectedTotal = 0
     let batchBudget: BatchBudgetTrace | undefined
+    // One real, turn-scoped live ControlState shared across every batch item — the same object the
+    // flag-OFF runBatchToolLoop path threads through resolveBatchItem / resolveRemainingBatchItems
+    // (createControlPlaneState). It must be a real createControlPlaneState() object, not a
+    // synthetic { controlState } wrapper: resolveBatchItem's shared runToolIterationStep calls
+    // recordToolOutcome unconditionally when a controlPlaneState is passed, and recordToolOutcome
+    // dereferences state.evidenceStore. Batch items don't pin toolCtx.controlState in the way the
+    // flat proposer does — they already cleared the message-level approval gate, and the flag-OFF
+    // batch path gates on this turn-scoped state alone too.
+    const controlPlaneState = this.createControlPlaneState()
 
     const proposer = async (_toolCtx: ToolExecutorContext): Promise<unknown> => {
-      // Unlike the flat createHarnessProposer, this does not fold toolCtx.controlState into a
-      // TurnControlPlaneState for resolveBatchItem/resolveRemainingBatchItems: those methods'
-      // shared runToolIterationStep unconditionally calls recordToolOutcome (the write side of
-      // Phase 4c's control-plane state) whenever a controlPlaneState is passed at all, and
-      // recordToolOutcome dereferences state.evidenceStore — a field a synthetic
-      // `{ controlState: toolCtx.controlState }` wrapper (the read-only shape R2's flat proposer
-      // builds) doesn't have. R2's own note already flagged the write-side half of the fold as
-      // deferred, buildable follow-up; discovering it crashes as soon as something exercises it
-      // (a real per-item tool dispatch, which the flat proposer's own test matrix never did) is
-      // this phase's actual finding — passing `undefined` here (no ControlState at all for batch
-      // items, matching the flat proposer's very first call before any ControlState is resolved)
-      // avoids the crash without inventing new write-side plumbing, and is flagged for a human to
-      // resolve properly (either a real evidenceStore-backed control-plane object, or fixing
-      // recordToolOutcome to tolerate a partial state) rather than silently left as a TODO.
-      const controlPlaneState = undefined
-
       if (phase === 'probe') {
         for (const item of probeItems) {
           probeResolutions.push(

--- a/packages/personal-assistant/src/assistant.ts
+++ b/packages/personal-assistant/src/assistant.ts
@@ -528,9 +528,10 @@ export class PersonalAssistant {
         // Phase 4c: one live ControlState per turn, shared across every tool call this turn
         // makes — including across batch items (see AgentLoop.createControlPlaneState /
         // tool-control-plane.ts) — so a failure pattern discovered partway through the turn can
-        // actually gate a later call via checkToolPolicy. Only needed on this branch: the
-        // harness-driven proposer above folds in the harness's own live ControlState instead
-        // (see createHarnessProposer's doc comment) rather than this separate structure.
+        // actually gate a later call via checkToolPolicy. The flag-ON harness-driven proposers
+        // above build their own via createControlPlaneState() too (and additionally pin the
+        // harness's own live per-iteration ControlState on as the gate floor — see
+        // createHarnessProposer's doc comment); this branch just constructs it here instead.
         const controlPlaneState = this.agentLoop.createControlPlaneState()
         const loopResult = batch
           ? await this.agentLoop.runBatchToolLoop(batch.items, sessionId, userMessage, systemPrompt, options.onToken, options.onToolStep, accumulateUsage, controlPlaneState)

--- a/packages/personal-assistant/src/one-loop-proposer.test.ts
+++ b/packages/personal-assistant/src/one-loop-proposer.test.ts
@@ -135,6 +135,36 @@ describe('AgentLoop.createHarnessProposer (R2 of the D2 one-loop-rewire follow-u
     expect((caught as OneLoopPause).result.kind).toBe('escalated')
   })
 
+  it('dispatches a real read-only tool call with a live harness ControlState present without crashing recordToolOutcome', async () => {
+    // Regression: R2's proposer wrapped toolCtx.controlState in a synthetic
+    // `{ controlState } as TurnControlPlaneState`, which has no evidenceStore — so the moment
+    // runToolIterationStep dispatched any non-staged tool call and reached recordToolOutcome
+    // (which dereferences state.evidenceStore), it threw `Cannot read properties of undefined`.
+    // The proposer now holds a real createControlPlaneState() object for the whole turn.
+    const llmClient = new ScriptedLLMClient([
+      { content: '', toolCalls: [{ id: 'toolu_1', name: 'read_file', input: { path: 'missing.txt' } }] },
+      { content: 'here is the answer' },
+    ])
+    const agentLoop = buildAgentLoop(llmClient)
+    const proposer = agentLoop.createHarnessProposer({
+      messages: [{ role: 'user', content: 'read missing.txt' }],
+      tools: [],
+      sessionId: 'session-1',
+      userMessage: 'read missing.txt',
+      maxIterations: 5,
+      sources: [],
+    })
+    // worldModel/evidenceStore left undefined on purpose — the proposer must not read them off
+    // toolCtx; it uses its own createControlPlaneState() stores for recordToolOutcome.
+    const toolCtx = { worldModel: undefined as never, evidenceStore: undefined as never, controlState: new ControlState() }
+
+    const first = await proposer(toolCtx)
+    expect(first).toEqual({ __harnessExecutionStatus: 'continue' })
+
+    const second = await proposer(toolCtx)
+    expect(second).toEqual({ __harnessExecutionStatus: 'complete', output: 'here is the answer' })
+  })
+
   it('never dispatches more than maxIterations calls — the final one throws an escalated OneLoopPause instead of hanging', async () => {
     const llmClient = new ScriptedLLMClient([
       { content: '<tool_call>' },


### PR DESCRIPTION
## What

Closes the ControlState write-side fold gap that R2/R4's implementation notes flagged as deferred follow-up — landed now because the R5 default-flip is exactly the caller that would trip it.

`createHarnessProposer` (flat) and `createBatchOneLoopProposer` (batch) wrapped `toolCtx.controlState` in a synthetic `{ controlState } as TurnControlPlaneState`. That shape has no `evidenceStore`, so the first time `runToolIterationStep` dispatched a non-staged tool call and reached `recordToolOutcome` (which dereferences `state.evidenceStore`), it threw `Cannot read properties of undefined`.

## Change

Both proposers now hold one real `createControlPlaneState()` object — the exact `TurnControlPlaneState` the flag-OFF `runToolLoop` / `runBatchToolLoop` path already threads through — for the lifetime of the turn.

- The flat proposer additionally pins the harness's own live per-iteration `toolCtx.controlState` on as the gate's floor at the start of every iteration (D2's "one composition, not two" intent) — a harness `DENY` / `HUMAN_REQUIRED` escalation is still honored by `checkToolPolicy` before the iteration's first call.
- `recordToolOutcome`'s per-call re-resolution only ever escalates further (8+ same-turn failures) and `evaluateToolPolicy` ignores `execution_mode`, so it never downgrades a harness escalation.
- The batch proposer shares one such state across every item (matching the flag-OFF batch path) and does not pin `toolCtx.controlState`, since batch items already cleared the message-level approval gate.

Net effect: flag-ON same-turn tool-failure-pattern gating now behaves identically to flag-OFF, plus the harness's own resolution as a floor.

## Flag state

`ASSISTANT_ONE_LOOP` / `DEFAULT_ONE_LOOP_MODE` untouched — still OFF by default on every surface. INV-19 (flag-OFF byte-identical) holds: no pre-existing assertion changed.

## Validation

- `packages/personal-assistant` suite **1053/1053**
- `tsc --noEmit` clean
- New regression test in `one-loop-proposer.test.ts`: a real `read_file` dispatch with a live `ControlState` on `toolCtx` — crashed before, completes cleanly now

Files: `agent-loop.ts` (both proposers), `assistant.ts` (one doc comment), `one-loop-proposer.test.ts` (+1 test), stats regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)