### PR TITLE
chat-ui / desktop browser E2E lane (B1–B4)

### DIFF
--- a/.github/workflows/browser-e2e.yml
+++ b/.github/workflows/browser-e2e.yml
@@ -1,0 +1,100 @@
+name: Browser E2E (chat-ui)
+
+# Real-browser end-to-end lane for plans/chat_ui_browser_e2e_plan.html phase B4.
+#
+# Runs the Playwright suite in packages/chat-ui/e2e (B2 harness + B3 flag OFF/ON
+# parity matrix) against a real Vite production-shape build served by `vite preview`
+# with VITE_E2E=1 — the surface jsdom cannot exercise (bundle, import.meta.env
+# substitution, CSP, real DOM/event loop). Chromium only: Playwright ships and
+# manages its own binary, works headless with no $DISPLAY on Linux.
+#
+# NOT a required check yet. Per the plan (R5 precedent — measure before you enforce),
+# this stays advisory until it has been green on the nightly schedule for at least a
+# week / 3+ consecutive runs. Do not add it to branch protection before then; promoting
+# it early risks a flaky-gate stall. Branch protection is a repo setting, not something
+# this file controls, so "non-blocking" here means "not registered as required".
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/chat-ui/**'
+      - 'packages/personal-assistant/**'
+      - 'packages/harness/**'
+      - 'packages/runtime/**'
+      - '.github/workflows/browser-e2e.yml'
+  schedule:
+    - cron: '0 4 * * *'   # nightly at 04:00 UTC (an hour after eval.yml's 03:00)
+  workflow_dispatch:
+
+concurrency:
+  group: browser-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  chromium:
+    name: chat-ui Playwright (Chromium, flag OFF/ON matrix)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install deps (root + workspaces)
+        run: npm ci
+
+      # chat-ui imports @buildaharness/{harness,runtime,personal-assistant} by
+      # workspace link with no source-path aliasing — their dist/ must exist before
+      # the e2e build bundles them (personal-assistant's build also pulls harness,
+      # but build them explicitly and in order to be safe).
+      - name: Build workspace deps
+        run: |
+          npm run build:harness
+          npm run build:runtime
+          npm run build:personal-assistant
+
+      # Cache the Playwright browser binaries, keyed by the resolved @playwright/test
+      # version so a bump busts the cache automatically.
+      - name: Resolve Playwright version
+        id: pw
+        working-directory: packages/chat-ui
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      - name: Install Chromium (with deps)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        working-directory: packages/chat-ui
+        run: npx playwright install --with-deps chromium
+
+      # OS-level deps only — the cached binary skips the download but still needs
+      # the shared libraries on a fresh runner image.
+      - name: Install Chromium OS deps
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        working-directory: packages/chat-ui
+        run: npx playwright install-deps chromium
+
+      - name: Run Playwright e2e
+        working-directory: packages/chat-ui
+        run: npm run test:e2e
+        env:
+          CI: 'true'
+
+      - name: Upload Playwright report + traces
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            packages/chat-ui/playwright-report/
+            packages/chat-ui/test-results/
+          retention-days: 14
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Version](https://img.shields.io/badge/version-v0.8.0-brightgreen.svg)](https://github.com/3IVIS/buildaharness/releases)
 [![Status](https://img.shields.io/badge/status-public%20alpha-orange.svg)](https://github.com/3IVIS/buildaharness)
-[![Tests](https://img.shields.io/badge/tests-3%2C231%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/tests-3%2C241%20passing-brightgreen.svg)](#)
 [![GitHub Stars](https://img.shields.io/github/stars/3IVIS/buildaharness?style=social)](https://github.com/3IVIS/buildaharness/stargazers)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Node.js](https://img.shields.io/badge/Node.js-18+-339933.svg?logo=node.js&logoColor=white)](https://nodejs.org/)

--- a/README_CN.md
+++ b/README_CN.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/许可证-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Version](https://img.shields.io/badge/版本-v0.8.0-brightgreen.svg)](https://github.com/3IVIS/buildaharness/releases)
 [![Status](https://img.shields.io/badge/状态-公开测试版-orange.svg)](https://github.com/3IVIS/buildaharness)
-[![Tests](https://img.shields.io/badge/测试-3%2C231%20通过-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/测试-3%2C241%20通过-brightgreen.svg)](#)
 [![GitHub Stars](https://img.shields.io/github/stars/3IVIS/buildaharness?style=social)](https://github.com/3IVIS/buildaharness/stargazers)
 [![PRs Welcome](https://img.shields.io/badge/欢迎-PR贡献-brightgreen.svg)](CONTRIBUTING.md)
 [![Node.js](https://img.shields.io/badge/Node.js-18+-339933.svg?logo=node.js&logoColor=white)](https://nodejs.org/)

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -8,9 +8,9 @@ not transcluded, since GitHub-rendered markdown has no include mechanism.
 
 | Metric | Count | Source |
 |---|---|---|
-| Frontend tests (vitest) | 2028 across 131 files | `npm test` (root — aggregates src/ and every packages/* workspace) |
+| Frontend tests (vitest) | 2038 across 134 files | `npm test` (root — aggregates src/ and every packages/* workspace) |
 | Adapter tests (pytest) | 1203 | `pytest adapter/tests/ -v` |
 | MAF adapter tests | 42 | `pytest adapter/tests/test_maf_adapter.py -v` |
-| Project-wide tests | 3,231 | pytest + vitest combined |
+| Project-wide tests | 3,241 | pytest + vitest combined |
 | Node types | 27 (14 execution + 13 harness) | `Node`/`HarnessNode` discriminated unions in `spec/schema.ts` |
 | Docker Compose services | 12 | `docker-compose.yml` top-level `services:` keys, excluding one-shot `restart: "no"` init jobs |

--- a/package-lock.json
+++ b/package-lock.json
@@ -2138,6 +2138,22 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -7854,6 +7870,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
@@ -10789,6 +10834,7 @@
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.63.0",
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.2",

--- a/packages/chat-ui/.gitignore
+++ b/packages/chat-ui/.gitignore
@@ -1,0 +1,6 @@
+# Browser-e2e lane (plans/chat_ui_browser_e2e_plan.html) — all generated, never committed.
+dist-e2e/
+playwright-report/
+test-results/
+playwright/.cache/
+blob-report/

--- a/packages/chat-ui/README.md
+++ b/packages/chat-ui/README.md
@@ -172,3 +172,38 @@ npm run build --workspace=packages/chat-ui
 npm test --workspace=packages/chat-ui
 npm run typecheck --workspace=packages/chat-ui
 ```
+
+## Browser end-to-end tests (Playwright)
+
+`npm test` here is jsdom-only, and `App.test.tsx` module-mocks `PersonalAssistant`
+entirely — so it never exercises the real `PersonalAssistant.create()` path through
+a real bundle. The `e2e/` suite closes that gap: it drives the actual Vite
+production-shape build (`VITE_E2E=1`, served by `vite preview`) in headless
+Chromium, with a scripted `ILLMClient` and an in-memory `FsBackend` injected
+through the B1 test seam (`src/e2e/e2e-runtime.ts`, `src/assistant-test-hooks.ts` —
+both compiled out of any non-E2E build, since `import.meta.env.VITE_E2E` folds to
+`false`). `e2e/parity.spec.ts` is the flag OFF-vs-ON parity matrix (benign turn,
+gated read-only tool call, staged `write_file` approve, staged `write_file` deny,
+failing tool call, escalation) run under both `oneLoopMode` states against a
+**single** build — B1 made `oneLoopMode` a runtime value, so `e2e/fixtures.ts`
+sets it per test via `addInitScript`.
+
+**On a dev machine or in CI:**
+
+```bash
+npm run test:e2e --workspace=packages/chat-ui   # playwright test — needs Chromium
+```
+
+Playwright manages its own browser binary; first run needs
+`npx playwright install --with-deps chromium`. The `webServer` block in
+`playwright.config.ts` does the `build:e2e` + `preview:e2e` itself, so there is no
+separate build step. CI runs this via `.github/workflows/browser-e2e.yml`
+(phase B4) on PRs touching `packages/chat-ui|personal-assistant|harness|runtime`
+plus a nightly cron.
+
+**This dev container cannot run `test:e2e`.** Per the repo `CLAUDE.md`: `$DISPLAY`
+is empty, there is no `Xvfb`/`xvfb-run`, system Firefox is a broken snap and there
+is no Chromium/Chrome. The only assistant-behaviour checks runnable in-sandbox are
+the B1 seam's jsdom tests — `src/App.e2e-seam.test.tsx` and
+`src/assistant-test-hooks.test.ts` — which verify the injection seam itself but not
+a real browser. See `plans/chat_ui_browser_e2e_plan.html` for the full rationale.

--- a/packages/chat-ui/e2e/fixtures.ts
+++ b/packages/chat-ui/e2e/fixtures.ts
@@ -1,9 +1,9 @@
-import { test as base, expect, type Page, type Locator } from '@playwright/test'
+import { test as base, expect, type BrowserContext, type Page, type Locator } from '@playwright/test'
 import type { ScriptedLLMClientScript } from '@buildaharness/personal-assistant'
 
 /**
  * Page objects + the `chat` fixture for the browser-e2e lane
- * (plans/chat_ui_browser_e2e_plan.html phase B2).
+ * (plans/chat_ui_browser_e2e_plan.html phases B2 + B3).
  *
  * A test calls `await chat({ script, oneLoopMode?, fsSeed? })` to boot the app with:
  *   - a deterministic scripted `ILLMClient` wired through the B1 seam (no proxy / key / network),
@@ -14,6 +14,9 @@ import type { ScriptedLLMClientScript } from '@buildaharness/personal-assistant'
  * All of this is installed by one `addInitScript` that runs before the app bundle. It can't
  * `import`, so it reaches the scripted-client / in-memory-FS constructors through
  * `window.__BAH_E2E_FACTORY__`, which the E2E build publishes (see src/e2e/e2e-runtime.ts).
+ *
+ * `chat` opens a **fresh page** per call, so a single B3 parity test can run the same scenario
+ * twice — once with the flag OFF, once ON — and diff the two.
  */
 
 /** localStorage key the browser config store reads — see src/browser-config-store.ts. */
@@ -31,6 +34,9 @@ export interface ChatBootstrap {
   fsSeed?: Record<string, string>
 }
 
+/** What `ChatPage.sendMessage` waits for after clicking Send. */
+export type SettleOn = 'reply' | 'approval' | 'halt'
+
 const INPUT_PLACEHOLDER = 'Message the assistant…'
 
 export class ChatPage {
@@ -47,15 +53,33 @@ export class ChatPage {
   /**
    * Type `text`, hit Send, and wait for the turn to land. The assistant is constructed in an
    * async mount effect; a send before it resolves lands a retryable "still starting up" error —
-   * click Retry if it shows, then wait for the turn's `proposer-kind` marker to appear.
+   * click Retry if it shows, then wait for whichever outcome `settleOn` names:
+   *   - `'reply'`    → the turn's `proposer-kind` marker appears (an assistant bubble rendered),
+   *   - `'approval'` → an approval card appears (a staged write/shell/etc.),
+   *   - `'halt'`     → the escalation banner appears (the tool loop gave up / HUMAN_REQUIRED).
    */
-  async sendMessage(text: string): Promise<void> {
+  async sendMessage(text: string, settleOn: SettleOn = 'reply'): Promise<void> {
     await this.input.fill(text)
     await this.page.getByRole('button', { name: 'Send', exact: true }).click()
+    const target =
+      settleOn === 'approval'
+        ? this.approvalCard()
+        : settleOn === 'halt'
+          ? this.haltBanner()
+          : this.proposerKindLocator
+    // The assistant builds in an async mount effect; a send before it resolves lands a retryable
+    // "still starting up" error. Click Retry at most once (a second click would fire a second
+    // turn and over-consume the scripted responses), then wait for the settle target.
+    let retried = false
     await expect(async () => {
-      const retry = this.page.getByRole('button', { name: 'Retry', exact: true })
-      if (await retry.count()) await retry.first().click()
-      await expect(this.proposerKindLocator).toBeAttached()
+      if (!retried && (await target.count()) === 0) {
+        const retry = this.page.getByRole('button', { name: 'Retry', exact: true })
+        if (await retry.count()) {
+          await retry.first().click()
+          retried = true
+        }
+      }
+      await expect(target).toBeAttached()
     }).toPass({ timeout: 15_000 })
   }
 
@@ -72,6 +96,21 @@ export class ChatPage {
     return this.page.locator('.approval-card')
   }
 
+  /** The `<div class="approval-card__resolution">` — `Approved.` / `Denied.` once resolved. */
+  approvalResolution(): Locator {
+    return this.page.locator('.approval-card__resolution').last()
+  }
+
+  /** The escalation / "Halted — needs your input" banner. */
+  haltBanner(): Locator {
+    return this.page.locator('.escalation-banner')
+  }
+
+  /** The bubble's "Steps (N)" toggle — present only when the turn ran ≥1 tool call. */
+  stepsToggle(): Locator {
+    return this.page.getByRole('button', { name: /^(Steps|Hide steps)/ })
+  }
+
   /** `'posthoc' | 'flat-oneloop' | 'batch-oneloop'` for the latest turn. */
   async proposerKind(): Promise<string> {
     return (await this.proposerKindLocator.textContent())?.trim() ?? ''
@@ -86,30 +125,33 @@ export class ChatPage {
   }
 }
 
+async function bootChatPage(context: BrowserContext, { script, oneLoopMode, fsSeed }: ChatBootstrap): Promise<ChatPage> {
+  const page = await context.newPage()
+  await page.addInitScript(
+    (args: { key: string; config: Record<string, unknown>; script: E2EScript; fsSeed: Record<string, string> }) => {
+      window.localStorage.setItem(args.key, JSON.stringify(args.config))
+      const w = window as unknown as Record<string, any>
+      w.__BAH_E2E__ = {
+        makeLlmClient: () => w.__BAH_E2E_FACTORY__.createScriptedLLMClient(args.script),
+        makeFsBackend: () => w.__BAH_E2E_FACTORY__.createInMemoryFsBackend(args.fsSeed),
+      }
+    },
+    {
+      key: CONFIG_STORAGE_KEY,
+      config: { llmBackend: 'proxy', ...(oneLoopMode ? { oneLoopMode } : {}) },
+      script,
+      fsSeed: fsSeed ?? {},
+    },
+  )
+  const chat = new ChatPage(page)
+  await page.goto('/')
+  await chat.waitReady()
+  return chat
+}
+
 export const test = base.extend<{ chat: (bootstrap: ChatBootstrap) => Promise<ChatPage> }>({
-  chat: async ({ page }, use) => {
-    await use(async ({ script, oneLoopMode, fsSeed }: ChatBootstrap) => {
-      await page.addInitScript(
-        (args: { key: string; config: Record<string, unknown>; script: E2EScript; fsSeed: Record<string, string> }) => {
-          window.localStorage.setItem(args.key, JSON.stringify(args.config))
-          const w = window as unknown as Record<string, any>
-          w.__BAH_E2E__ = {
-            makeLlmClient: () => w.__BAH_E2E_FACTORY__.createScriptedLLMClient(args.script),
-            makeFsBackend: () => w.__BAH_E2E_FACTORY__.createInMemoryFsBackend(args.fsSeed),
-          }
-        },
-        {
-          key: CONFIG_STORAGE_KEY,
-          config: { llmBackend: 'proxy', ...(oneLoopMode ? { oneLoopMode } : {}) },
-          script,
-          fsSeed: fsSeed ?? {},
-        },
-      )
-      const chat = new ChatPage(page)
-      await page.goto('/')
-      await chat.waitReady()
-      return chat
-    })
+  chat: async ({ context }, use) => {
+    await use((bootstrap: ChatBootstrap) => bootChatPage(context, bootstrap))
   },
 })
 

--- a/packages/chat-ui/e2e/fixtures.ts
+++ b/packages/chat-ui/e2e/fixtures.ts
@@ -1,0 +1,116 @@
+import { test as base, expect, type Page, type Locator } from '@playwright/test'
+import type { ScriptedLLMClientScript } from '@buildaharness/personal-assistant'
+
+/**
+ * Page objects + the `chat` fixture for the browser-e2e lane
+ * (plans/chat_ui_browser_e2e_plan.html phase B2).
+ *
+ * A test calls `await chat({ script, oneLoopMode?, fsSeed? })` to boot the app with:
+ *   - a deterministic scripted `ILLMClient` wired through the B1 seam (no proxy / key / network),
+ *   - an in-memory `FsBackend` so the tool loop actually runs,
+ *   - `oneLoopMode` persisted into `buildaharness.personal-assistant.config` so a *single*
+ *     preview build covers both flag states (B1 made the flag a runtime value).
+ *
+ * All of this is installed by one `addInitScript` that runs before the app bundle. It can't
+ * `import`, so it reaches the scripted-client / in-memory-FS constructors through
+ * `window.__BAH_E2E_FACTORY__`, which the E2E build publishes (see src/e2e/e2e-runtime.ts).
+ */
+
+/** localStorage key the browser config store reads — see src/browser-config-store.ts. */
+const CONFIG_STORAGE_KEY = 'buildaharness.personal-assistant.config'
+
+/** The scripted-LLM script, minus `classify` (a function — not structured-clonable across `addInitScript`). */
+export type E2EScript = Omit<ScriptedLLMClientScript, 'classify'>
+
+export interface ChatBootstrap {
+  /** The scripted LLM conversation for this test. */
+  script: E2EScript
+  /** Persisted one-loop flag state. Omit → the app default (currently `disabled`). */
+  oneLoopMode?: 'enabled' | 'disabled'
+  /** Files the in-memory FsBackend is pre-populated with (keys are absolute, under `/workspace`). */
+  fsSeed?: Record<string, string>
+}
+
+const INPUT_PLACEHOLDER = 'Message the assistant…'
+
+export class ChatPage {
+  constructor(readonly page: Page) {}
+
+  private get input(): Locator {
+    return this.page.getByPlaceholder(INPUT_PLACEHOLDER)
+  }
+
+  async waitReady(): Promise<void> {
+    await this.input.waitFor({ state: 'visible' })
+  }
+
+  /**
+   * Type `text`, hit Send, and wait for the turn to land. The assistant is constructed in an
+   * async mount effect; a send before it resolves lands a retryable "still starting up" error —
+   * click Retry if it shows, then wait for the turn's `proposer-kind` marker to appear.
+   */
+  async sendMessage(text: string): Promise<void> {
+    await this.input.fill(text)
+    await this.page.getByRole('button', { name: 'Send', exact: true }).click()
+    await expect(async () => {
+      const retry = this.page.getByRole('button', { name: 'Retry', exact: true })
+      if (await retry.count()) await retry.first().click()
+      await expect(this.proposerKindLocator).toBeAttached()
+    }).toPass({ timeout: 15_000 })
+  }
+
+  private get proposerKindLocator(): Locator {
+    return this.page.getByTestId('proposer-kind').last()
+  }
+
+  /** The rendered text of the most recent assistant message bubble. */
+  lastAssistantBubble(): Locator {
+    return this.page.locator('.bubble__content--markdown').last()
+  }
+
+  approvalCard(): Locator {
+    return this.page.locator('.approval-card')
+  }
+
+  /** `'posthoc' | 'flat-oneloop' | 'batch-oneloop'` for the latest turn. */
+  async proposerKind(): Promise<string> {
+    return (await this.proposerKindLocator.textContent())?.trim() ?? ''
+  }
+
+  async approve(): Promise<void> {
+    await this.approvalCard().getByRole('button', { name: 'Approve', exact: true }).click()
+  }
+
+  async deny(): Promise<void> {
+    await this.approvalCard().getByRole('button', { name: 'Deny', exact: true }).click()
+  }
+}
+
+export const test = base.extend<{ chat: (bootstrap: ChatBootstrap) => Promise<ChatPage> }>({
+  chat: async ({ page }, use) => {
+    await use(async ({ script, oneLoopMode, fsSeed }: ChatBootstrap) => {
+      await page.addInitScript(
+        (args: { key: string; config: Record<string, unknown>; script: E2EScript; fsSeed: Record<string, string> }) => {
+          window.localStorage.setItem(args.key, JSON.stringify(args.config))
+          const w = window as unknown as Record<string, any>
+          w.__BAH_E2E__ = {
+            makeLlmClient: () => w.__BAH_E2E_FACTORY__.createScriptedLLMClient(args.script),
+            makeFsBackend: () => w.__BAH_E2E_FACTORY__.createInMemoryFsBackend(args.fsSeed),
+          }
+        },
+        {
+          key: CONFIG_STORAGE_KEY,
+          config: { llmBackend: 'proxy', ...(oneLoopMode ? { oneLoopMode } : {}) },
+          script,
+          fsSeed: fsSeed ?? {},
+        },
+      )
+      const chat = new ChatPage(page)
+      await page.goto('/')
+      await chat.waitReady()
+      return chat
+    })
+  },
+})
+
+export { expect }

--- a/packages/chat-ui/e2e/parity.spec.ts
+++ b/packages/chat-ui/e2e/parity.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect, type ChatBootstrap, type ChatPage, type SettleOn } from './fixtures'
+import type { LLMStructuredResponse } from '@buildaharness/runtime'
+
+/**
+ * B3 — the flag OFF-vs-ON parity matrix (plans/chat_ui_browser_e2e_plan.html phase B3).
+ *
+ * The same shape as R5's CLI live-verification, now in a real browser, run under both
+ * `oneLoopMode` states. Each scenario is one deterministic scripted-LLM conversation. The
+ * assertion in every case: the flag changes *which proposer ran* (`proposerKind`) but not the
+ * user-visible outcome — reply text, whether an approval card appeared, whether the turn
+ * halted. That "same path-independent result" is exactly the evidence R5's `DEFAULT_ONE_LOOP_MODE`
+ * flip needs.
+ *
+ * This spec cannot run in the buildaharness dev container (no Chromium). It runs on a dev machine
+ * (`npm run test:e2e` in packages/chat-ui) or in CI (phase B4).
+ */
+
+const WORKSPACE = '/workspace'
+
+/** A model turn that calls one tool, then (optionally) more responses follow for the loop. */
+function toolCall(name: string, input: Record<string, unknown>): LLMStructuredResponse {
+  return { content: '', toolCalls: [{ id: `call_${name}`, name, input }] }
+}
+
+interface ScenarioRun {
+  reply: string
+  proposerKind: string
+  sawApprovalCard: boolean
+  sawHalt: boolean
+}
+
+async function runScenario(
+  chat: (b: ChatBootstrap) => Promise<ChatPage>,
+  oneLoopMode: 'disabled' | 'enabled',
+  message: string,
+  bootstrap: Omit<ChatBootstrap, 'oneLoopMode'>,
+  settleOn: SettleOn,
+): Promise<{ page: ChatPage } & ScenarioRun> {
+  const page = await chat({ ...bootstrap, oneLoopMode })
+  await page.sendMessage(message, settleOn)
+  const sawApprovalCard = (await page.approvalCard().count()) > 0
+  const sawHalt = (await page.haltBanner().count()) > 0
+  const reply = settleOn === 'reply' ? ((await page.lastAssistantBubble().textContent()) ?? '').trim() : ''
+  const proposerKind = settleOn === 'reply' ? await page.proposerKind() : ''
+  return { page, reply, proposerKind, sawApprovalCard, sawHalt }
+}
+
+test.describe('flag OFF vs ON parity matrix', () => {
+  test('benign, no tools — identical reply, proposerKind flips', async ({ chat }) => {
+    const script = { responses: ['84'], streamChunks: ['84'] }
+    const off = await runScenario(chat, 'disabled', 'What is 12 x 7?', { script }, 'reply')
+    const on = await runScenario(chat, 'enabled', 'What is 12 x 7?', { script }, 'reply')
+
+    expect(off.reply).toMatch(/84/)
+    expect(on.reply).toBe(off.reply)
+    expect(off.sawApprovalCard).toBe(false)
+    expect(on.sawApprovalCard).toBe(false)
+    expect(off.proposerKind).toBe('posthoc')
+    expect(on.proposerKind).toBe('flat-oneloop')
+  })
+
+  test('read-only tool call, gated — file content in the reply, tool step shown, no staging', async ({ chat }) => {
+    const bootstrap = {
+      fsSeed: { [`${WORKSPACE}/report.txt`]: 'quarterly numbers: 42' },
+      script: {
+        responses: [toolCall('read_file', { path: 'report.txt' }), 'The report says: quarterly numbers: 42.'],
+        streamChunks: ['The report says: quarterly numbers: 42.'],
+      },
+    }
+    const off = await runScenario(chat, 'disabled', 'Read report.txt and tell me the number', bootstrap, 'reply')
+    const on = await runScenario(chat, 'enabled', 'Read report.txt and tell me the number', bootstrap, 'reply')
+
+    for (const run of [off, on]) {
+      expect(run.reply).toContain('quarterly numbers: 42')
+      expect(run.sawApprovalCard).toBe(false) // read-only → gated, never staged for approval
+      await expect(run.page.stepsToggle()).toBeVisible() // the tool call surfaced as a step
+      await expect(run.page.haltBanner()).toHaveCount(0) // the ControlState gate ran without erroring
+    }
+    expect(on.reply).toBe(off.reply)
+    expect(off.proposerKind).toBe('posthoc')
+    expect(on.proposerKind).toBe('flat-oneloop')
+  })
+
+  test('write staged for approval — card appears with kind "write", approve applies it', async ({ chat }) => {
+    const bootstrap = {
+      script: { responses: [toolCall('write_file', { path: 'summary.md', content: 'draft summary' })] },
+    }
+    for (const mode of ['disabled', 'enabled'] as const) {
+      const run = await runScenario(chat, mode, 'Write a summary to summary.md', bootstrap, 'approval')
+      expect(run.sawApprovalCard).toBe(true)
+      await expect(run.page.approvalCard()).toContainText('write')
+
+      await run.page.approve()
+      await expect(run.page.approvalResolution()).toHaveText('Approved.')
+      await expect(run.page.lastAssistantBubble()).toContainText(/Wrote .summary\.md./)
+    }
+  })
+
+  test('write staged for approval — deny discards it', async ({ chat }) => {
+    const bootstrap = {
+      script: { responses: [toolCall('write_file', { path: 'summary.md', content: 'never applied' })] },
+    }
+    for (const mode of ['disabled', 'enabled'] as const) {
+      const run = await runScenario(chat, mode, 'Write a summary to summary.md', bootstrap, 'approval')
+      expect(run.sawApprovalCard).toBe(true)
+
+      await run.page.deny()
+      await expect(run.page.approvalResolution()).toHaveText('Denied.')
+      await expect(run.page.lastAssistantBubble()).toContainText('Cancelled')
+    }
+  })
+
+  test('failing tool call — no crash, the reply acknowledges the failure, turn completes', async ({ chat }) => {
+    const bootstrap = {
+      fsSeed: {} as Record<string, string>,
+      script: {
+        responses: [
+          toolCall('read_file', { path: 'nope.txt' }),
+          'I could not read nope.txt — it does not exist, so I cannot summarize it.',
+        ],
+        streamChunks: ['I could not read nope.txt — it does not exist, so I cannot summarize it.'],
+      },
+    }
+    const off = await runScenario(chat, 'disabled', 'Summarize nope.txt', bootstrap, 'reply')
+    const on = await runScenario(chat, 'enabled', 'Summarize nope.txt', bootstrap, 'reply')
+
+    for (const run of [off, on]) {
+      expect(run.reply).toContain('could not read nope.txt')
+      expect(run.sawHalt).toBe(false) // recovered inside the turn, not an escalation
+    }
+    expect(on.reply).toBe(off.reply)
+    expect(off.proposerKind).toBe('posthoc')
+    expect(on.proposerKind).toBe('flat-oneloop')
+  })
+
+  test('escalation — a model stuck in a tool loop halts in the UI, never hangs silently', async ({ chat }) => {
+    // The model never produces a final answer — it just keeps calling the same tool. The flat
+    // loop's maxIterations cap (or the turn-scoped ControlState gate escalating first) turns that
+    // into a clean `escalated` result, surfaced as the "Halted — needs your input" banner.
+    const bootstrap = {
+      fsSeed: { [`${WORKSPACE}/report.txt`]: 'quarterly numbers: 42' },
+      script: {
+        responses: Array.from({ length: 20 }, () => toolCall('read_file', { path: 'report.txt' })),
+      },
+    }
+    for (const mode of ['disabled', 'enabled'] as const) {
+      const run = await runScenario(chat, mode, 'Keep reading report.txt forever', bootstrap, 'halt')
+      expect(run.sawHalt).toBe(true)
+      await expect(run.page.haltBanner()).toContainText('Halted')
+      await expect(run.page.lastAssistantBubble()).toHaveCount(0) // no fabricated answer
+    }
+  })
+})

--- a/packages/chat-ui/e2e/smoke.spec.ts
+++ b/packages/chat-ui/e2e/smoke.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from './fixtures'
+
+/**
+ * B2 smoke: prove the harness is real (load the app, type, read a scripted reply), and that the
+ * B1 `proposerKind` telemetry surfaces in a real browser under both flag states. The full
+ * OFF-vs-ON parity matrix is phase B3.
+ *
+ * This spec cannot run in the buildaharness dev container (no Chromium). It runs on a dev machine
+ * (`npm run test:e2e` in packages/chat-ui) or in CI (phase B4).
+ */
+
+test('load app, send a message, get a scripted reply — no tools, no approval card', async ({ chat }) => {
+  const page = await chat({
+    script: { responses: ['Hello from the scripted client.'], streamChunks: ['Hello from the scripted client.'] },
+  })
+
+  await page.sendMessage('hi')
+
+  await expect(page.lastAssistantBubble()).toHaveText(/Hello from the scripted client\./)
+  await expect(page.approvalCard()).toHaveCount(0)
+  expect(await page.proposerKind()).toBe('posthoc')
+})
+
+test('persisted oneLoopMode "enabled" flips proposerKind to flat-oneloop', async ({ chat }) => {
+  const page = await chat({
+    oneLoopMode: 'enabled',
+    script: { responses: ['84'], streamChunks: ['84'] },
+  })
+
+  await page.sendMessage('What is 12 x 7?')
+
+  await expect(page.lastAssistantBubble()).toHaveText(/84/)
+  expect(await page.proposerKind()).toBe('flat-oneloop')
+})

--- a/packages/chat-ui/package.json
+++ b/packages/chat-ui/package.json
@@ -8,7 +8,10 @@
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "build:e2e": "VITE_E2E=1 vite build --outDir dist-e2e",
+    "preview:e2e": "vite preview --outDir dist-e2e --port 4173 --strictPort",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@buildaharness/personal-assistant": "^0.2.0",
@@ -23,6 +26,7 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.63.0",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",

--- a/packages/chat-ui/playwright.config.ts
+++ b/packages/chat-ui/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Browser E2E lane for plans/chat_ui_browser_e2e_plan.html phase B2.
+ *
+ * Chromium only (Playwright ships and manages its own binary — works headless with no `$DISPLAY`
+ * on Linux; system Firefox here is a broken snap, system Chrome is absent). The app under test is
+ * a real Vite production-shape build with `VITE_E2E=1`, served by `vite preview`, so the bundle,
+ * `import.meta.env` substitution and CSP are all exercised for real — the gap jsdom can't close.
+ *
+ * The `oneLoopMode` ON/OFF matrix runs against a **single** build: B1 made the flag a runtime
+ * value (a persisted `buildaharness.personal-assistant.config` entry), so `e2e/fixtures.ts` sets
+ * it per-test via `addInitScript` rather than needing two preview builds.
+ *
+ * This config cannot run in the buildaharness dev container (no Chromium, no `npx playwright
+ * install`). It is exercised on a dev machine / in CI (phase B4).
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['html', { open: 'never' }], ['list']] : 'list',
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: process.env.CI ? 'on-first-retry' : 'off',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run build:e2e && npm run preview:e2e',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+})

--- a/packages/chat-ui/src/App.e2e-seam.test.tsx
+++ b/packages/chat-ui/src/App.e2e-seam.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createScriptedLLMClient } from '@buildaharness/personal-assistant'
+import { App } from './App'
+import { setAssistantTestHooks } from './assistant-test-hooks'
+import { createInMemoryFsBackend } from './e2e/in-memory-fs-backend'
+
+/**
+ * The "extended jsdom test" from plans/chat_ui_browser_e2e_plan.html's rejected-alternatives
+ * list, now earned as phase B1's own coverage: NO module-wide `vi.mock` of
+ * `@buildaharness/personal-assistant` — a real `PersonalAssistant` runs against a scripted
+ * `ILLMClient` injected through the B1 seam, mounted in `<App/>`, on a real `turn()`.
+ *
+ * Asserts (a) flag OFF → proposerKind 'posthoc', (b) a persisted `oneLoopMode: 'enabled'` →
+ * 'flat-oneloop', (c) identical reply text both ways.
+ */
+
+const STORAGE_KEY = 'buildaharness.personal-assistant.config'
+const SEED = { '/workspace/note.txt': 'the note says hi' }
+const SCRIPT = () => ({
+  responses: [
+    { content: '', toolCalls: [{ id: 't1', name: 'read_file', input: { path: 'note.txt' } }] },
+    'The note says hi.',
+  ],
+  // The flat tool loop streams its final answer via callChat once no more tool calls come — keep
+  // that text the same as the structured final response so either path yields an identical reply.
+  streamChunks: ['The note says hi.'],
+})
+
+function installSeam(): void {
+  setAssistantTestHooks({
+    makeLlmClient: () => createScriptedLLMClient(SCRIPT()),
+    makeFsBackend: () => createInMemoryFsBackend(SEED),
+  })
+}
+
+async function sendAndReadReply(message: string): Promise<{ kind: string; reply: string }> {
+  const user = userEvent.setup()
+  const { container } = render(<App />)
+  const input = await screen.findByPlaceholderText('Message the assistant…')
+
+  // The assistant is built in an async mount effect; a send before it resolves lands a
+  // retryable "still starting up" error entry. Send, then retry via that button if it appears.
+  await user.type(input, message)
+  await user.click(screen.getByRole('button', { name: 'Send' }))
+  await waitFor(
+    async () => {
+      const retry = screen.queryByRole('button', { name: /retry/i })
+      if (retry) await user.click(retry)
+      expect(screen.getByTestId('proposer-kind')).toBeInTheDocument()
+    },
+    { timeout: 10000 },
+  )
+
+  const bubbles = container.querySelectorAll('.bubble__content--markdown')
+  return {
+    kind: screen.getByTestId('proposer-kind').textContent ?? '',
+    reply: bubbles.length > 0 ? (bubbles[bubbles.length - 1].textContent ?? '').trim() : '',
+  }
+}
+
+describe('App — B1 LLM injection seam', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('no network in tests')))
+  })
+  afterEach(() => {
+    cleanup()
+    setAssistantTestHooks(null)
+    localStorage.clear()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('flag OFF → proposerKind "posthoc"', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ llmBackend: 'proxy' }))
+    installSeam()
+    const { kind, reply } = await sendAndReadReply('read note.txt for me')
+    expect(kind).toBe('posthoc')
+    expect(reply.length).toBeGreaterThan(0)
+  })
+
+  it('persisted oneLoopMode "enabled" → proposerKind "flat-oneloop", identical reply text', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ llmBackend: 'proxy' }))
+    installSeam()
+    const off = await sendAndReadReply('read note.txt for me')
+
+    cleanup()
+    setAssistantTestHooks(null)
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ llmBackend: 'proxy', oneLoopMode: 'enabled' }))
+    installSeam()
+    const on = await sendAndReadReply('read note.txt for me')
+
+    expect(off.kind).toBe('posthoc')
+    expect(on.kind).toBe('flat-oneloop')
+    // Parity: the flag changes which path ran, not the user-visible reply (INV-19).
+    expect(on.reply).toBe(off.reply)
+  })
+})

--- a/packages/chat-ui/src/App.tsx
+++ b/packages/chat-ui/src/App.tsx
@@ -47,6 +47,7 @@ import { SearchPanel } from './components/SearchPanel'
 import { BrowserConfigStore } from './browser-config-store'
 import { TauriConfigStore } from './tauri-config-store'
 import { envOverridesFromImportMetaEnv } from './browser-config'
+import { getAssistantTestHooks } from './assistant-test-hooks'
 import { DEMO_USER_MESSAGE, DEMO_APPROVAL_REASON, DEMO_NOTE } from './demo-seed'
 import { checkProxyReachable, checkClaudeAvailable, checkWorkspaceConfigured, checkDataDirWritable } from './gui-doctor-checks'
 import type { ChatEntry } from './types'
@@ -148,6 +149,10 @@ async function createConfigStore(): Promise<ConfigStore> {
  * webview alike, so this is the one part of client selection that needs no isDesktop branch.
  */
 function createLlmClient(config: AssistantConfig, { isDesktop, workspaceRoot }: { isDesktop: boolean; workspaceRoot: string }): ILLMClient {
+  // Test-only injection seam (plans/chat_ui_browser_e2e_plan.html phase B1) — returns null in any
+  // production build, so this is byte-identical to the switch below there.
+  const testLlmClient = getAssistantTestHooks()?.makeLlmClient
+  if (testLlmClient) return testLlmClient(config)
   switch (config.llmBackend) {
     case 'claude-cli':
       if (isDesktop) return new TauriClaudeCliLLMClient({ fileTools: { workspaceRoot }, shellTools: config.enableShell })
@@ -231,12 +236,16 @@ async function createTauriBackedAssistant(config: AssistantConfig): Promise<Pers
 
 async function buildAssistant(config: AssistantConfig): Promise<PersonalAssistant> {
   if (isTauri()) return createTauriBackedAssistant(config)
+  // Test-only (phase B1): an injected in-memory FsBackend so the tool loop actually runs in a
+  // plain-browser E2E turn. `getAssistantTestHooks()` is null in any production build.
+  const testFsBackend = getAssistantTestHooks()?.makeFsBackend
   return PersonalAssistant.create({
     llmClient: createLlmClient(config, { isDesktop: false, workspaceRoot: '' }),
     model: config.model,
     // No fileTools/shellTools in a plain browser build (no filesystem/process access at all) —
     // still worth honoring dangerouslySkipPermissions for consistency with the desktop build,
     // since it also affects the message-level risk gate, independent of file/shell tools.
+    fileTools: testFsBackend ? { backend: testFsBackend(), workspaceRoot: '/workspace' } : undefined,
     webTools: config.enableWeb ? await createWebTools(config, false) : undefined,
     dangerouslySkipPermissions: config.dangerouslySkipPermissions,
     // R5 of plans/harness_d2_one_loop_rewire_plan.html — same AssistantConfig seam as the desktop
@@ -492,6 +501,7 @@ export function App(): React.JSX.Element {
             toolSteps: toolSteps.length > 0 ? toolSteps : undefined,
             planStatus: result.planStatus,
             answerClaim: result.answerClaim,
+            proposerKind: result.proposerKind,
           },
         ])
         setActivePlanStatus(result.planStatus)
@@ -659,6 +669,7 @@ export function App(): React.JSX.Element {
                   toolSteps={entry.toolSteps}
                   planStatus={entry.planStatus}
                   answerClaim={entry.answerClaim}
+                  proposerKind={entry.proposerKind}
                 />
               )
             case 'error':

--- a/packages/chat-ui/src/assistant-test-hooks.test.ts
+++ b/packages/chat-ui/src/assistant-test-hooks.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { assistantTestHooksEnabled, setAssistantTestHooks, getAssistantTestHooks } from './assistant-test-hooks'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  setAssistantTestHooks(null)
+})
+
+describe('assistant-test-hooks — production-bundle safety', () => {
+  it('is enabled under the test runner (MODE === "test")', () => {
+    expect(assistantTestHooksEnabled()).toBe(true)
+  })
+
+  it('no-ops setting hooks, and never returns them, in a production build', () => {
+    vi.stubEnv('MODE', 'production')
+    vi.stubEnv('VITE_E2E', '')
+    expect(assistantTestHooksEnabled()).toBe(false)
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    setAssistantTestHooks({ makeLlmClient: () => ({}) as never })
+    expect(warn).toHaveBeenCalled()
+    expect(getAssistantTestHooks()).toBeNull()
+    warn.mockRestore()
+  })
+
+  it('ignores window.__BAH_E2E__ in a production build', () => {
+    vi.stubEnv('MODE', 'production')
+    vi.stubEnv('VITE_E2E', '')
+    ;(window as unknown as Record<string, unknown>).__BAH_E2E__ = { makeLlmClient: () => ({}) as never }
+    try {
+      expect(getAssistantTestHooks()).toBeNull()
+    } finally {
+      delete (window as unknown as Record<string, unknown>).__BAH_E2E__
+    }
+  })
+
+  it('round-trips an in-process hook when enabled', () => {
+    const hooks = { makeFsBackend: () => ({}) as never }
+    setAssistantTestHooks(hooks)
+    expect(getAssistantTestHooks()).toBe(hooks)
+  })
+})

--- a/packages/chat-ui/src/assistant-test-hooks.ts
+++ b/packages/chat-ui/src/assistant-test-hooks.ts
@@ -1,0 +1,57 @@
+import type { AssistantConfig } from '@buildaharness/personal-assistant'
+import type { ILLMClient, FsBackend } from '@buildaharness/runtime'
+
+/**
+ * The one narrow, test-only seam for substituting what `buildAssistant()` /
+ * `createTauriBackedAssistant()` construct — an injected {@link ILLMClient} (so an E2E turn is
+ * byte-deterministic with no proxy / key / network) and, optionally, an in-memory
+ * {@link FsBackend} (so `fileTools` is configured and the tool loop actually runs).
+ *
+ * Built for plans/chat_ui_browser_e2e_plan.html phase B1. Flag-OFF and no-hook behaviour is
+ * byte-identical to today: {@link getAssistantTestHooks} returns `null` unless E2E mode is on.
+ *
+ * Two ways to install a hook, both gated on E2E mode:
+ *   - {@link setAssistantTestHooks} — from a jsdom/unit test in the same module graph.
+ *   - `window.__BAH_E2E__` — a Playwright `addInitScript` stashes a hooks object there before
+ *     the app bundle runs; {@link getAssistantTestHooks} reads it when no in-process hook is set.
+ *     This is what lets a *single* preview build cover both `oneLoopMode` states (the flag becomes
+ *     a runtime value from the injected client's config, not a build constant).
+ */
+export interface AssistantTestHooks {
+  makeLlmClient?: (config: AssistantConfig) => ILLMClient
+  makeFsBackend?: () => FsBackend
+}
+
+const WINDOW_KEY = '__BAH_E2E__'
+
+/**
+ * True only in a test/E2E build — `MODE === 'test'` under Vitest, or an explicit `VITE_E2E=1` for
+ * a Playwright preview build. A production bundle can never satisfy either, so the seam is
+ * unreachable there. Read lazily (not a module const) so a unit test can flip it via
+ * `vi.stubEnv('MODE', 'production')`.
+ */
+export function assistantTestHooksEnabled(): boolean {
+  return import.meta.env.MODE === 'test' || import.meta.env.VITE_E2E === '1'
+}
+
+let inProcessHooks: AssistantTestHooks | null = null
+
+/** Installs (or, with `null`, clears) the in-process hooks. No-ops with a warning outside E2E mode. */
+export function setAssistantTestHooks(hooks: AssistantTestHooks | null): void {
+  if (!assistantTestHooksEnabled()) {
+    console.warn('[chat-ui] setAssistantTestHooks() ignored — not a test/E2E build.')
+    return
+  }
+  inProcessHooks = hooks
+}
+
+/** The active hooks, or `null`. Prefers an in-process hook; falls back to `window.__BAH_E2E__`. */
+export function getAssistantTestHooks(): AssistantTestHooks | null {
+  if (!assistantTestHooksEnabled()) return null
+  if (inProcessHooks) return inProcessHooks
+  if (typeof window !== 'undefined') {
+    const fromWindow = (window as unknown as Record<string, unknown>)[WINDOW_KEY]
+    if (fromWindow && typeof fromWindow === 'object') return fromWindow as AssistantTestHooks
+  }
+  return null
+}

--- a/packages/chat-ui/src/components/ChatMessageBubble.tsx
+++ b/packages/chat-ui/src/components/ChatMessageBubble.tsx
@@ -31,8 +31,18 @@ interface Props {
   toolSteps?: AssistantToolStep[]
   planStatus?: AssistantTurnResult['planStatus']
   answerClaim?: AnswerClaim
+  /**
+   * Which proposer drove this turn (see AssistantTurnResult.proposerKind). Rendered only as a
+   * hidden `data-testid="proposer-kind"` element, and only in a dev/E2E build — a test affordance
+   * for plans/chat_ui_browser_e2e_plan.html phase B1's flag-OFF-vs-ON parity assertions, never a
+   * user-facing or documented public surface.
+   */
+  proposerKind?: AssistantTurnResult['proposerKind']
   onRetry?: () => void
 }
+
+/** True in `vite dev`, an explicit `VITE_E2E=1` preview build, or under the test runner — never a production bundle. */
+const SHOW_E2E_AFFORDANCES = import.meta.env.DEV || import.meta.env.MODE === 'test' || import.meta.env.VITE_E2E === '1'
 
 // Same icon convention plan-store.ts's STATUS_ICON / cli.ts's PLAN_TASK_STATUS_ICON already
 // use — kept in sync by hand rather than importing a string-keyed const across the package
@@ -98,7 +108,7 @@ const SOURCE_TOOL_LABEL: Record<AssistantSource['tool'], string> = {
 // doesn't vouch for the same way it does its own workspace files.
 const EXTERNAL_SOURCE_TOOLS: ReadonlySet<AssistantSource['tool']> = new Set(['web_search', 'fetch_url'])
 
-export function ChatMessageBubble({ role, content, riskLevel, trace, harnessSkipped, sources, toolSteps, planStatus, answerClaim, onRetry }: Props): React.JSX.Element {
+export function ChatMessageBubble({ role, content, riskLevel, trace, harnessSkipped, sources, toolSteps, planStatus, answerClaim, proposerKind, onRetry }: Props): React.JSX.Element {
   const [showWhy, setShowWhy] = useState(false)
   const [showSources, setShowSources] = useState(false)
   const [showSteps, setShowSteps] = useState(false)
@@ -113,6 +123,9 @@ export function ChatMessageBubble({ role, content, riskLevel, trace, harnessSkip
 
   return (
     <div className={`bubble bubble--${role}`}>
+      {SHOW_E2E_AFFORDANCES && proposerKind && (
+        <span data-testid="proposer-kind" hidden>{proposerKind}</span>
+      )}
       <button type="button" className="bubble__copy" onClick={handleCopy} aria-label="Copy message">
         {copied ? 'Copied' : 'Copy'}
       </button>

--- a/packages/chat-ui/src/e2e/e2e-runtime.ts
+++ b/packages/chat-ui/src/e2e/e2e-runtime.ts
@@ -1,0 +1,41 @@
+import { createScriptedLLMClient } from '@buildaharness/personal-assistant'
+import type { ScriptedLLMClientScript } from '@buildaharness/personal-assistant'
+import { createInMemoryFsBackend } from './in-memory-fs-backend'
+
+/**
+ * The browser-side half of the B2 Playwright harness (plans/chat_ui_browser_e2e_plan.html).
+ *
+ * A Playwright `addInitScript` runs in the page *before* the app bundle and cannot `import`
+ * anything, so it can't build the {@link import('../assistant-test-hooks').AssistantTestHooks}
+ * object directly — those need `createScriptedLLMClient` / `createInMemoryFsBackend`, which live
+ * in the bundle. This module bridges the gap: it is imported by `main.tsx` **only** when
+ * `import.meta.env.VITE_E2E === '1'` (a constant folded to `false` in any production build, so the
+ * whole dynamic import is tree-shaken away), and it publishes those two factories on
+ * `window.__BAH_E2E_FACTORY__`. The init script then does:
+ *
+ * ```js
+ * window.__BAH_E2E__ = {
+ *   makeLlmClient: () => window.__BAH_E2E_FACTORY__.createScriptedLLMClient(script),
+ *   makeFsBackend: () => window.__BAH_E2E_FACTORY__.createInMemoryFsBackend(fsSeed),
+ * }
+ * ```
+ *
+ * `getAssistantTestHooks()` reads `window.__BAH_E2E__`; the factory calls resolve later, once the
+ * app is building its assistant, by which point this module has run.
+ */
+export interface E2EFactory {
+  createScriptedLLMClient: (script: ScriptedLLMClientScript) => ReturnType<typeof createScriptedLLMClient>
+  createInMemoryFsBackend: (seed?: Record<string, string>) => ReturnType<typeof createInMemoryFsBackend>
+}
+
+declare global {
+  interface Window {
+    __BAH_E2E_FACTORY__?: E2EFactory
+  }
+}
+
+export function installE2EFactory(): void {
+  window.__BAH_E2E_FACTORY__ = { createScriptedLLMClient, createInMemoryFsBackend }
+}
+
+installE2EFactory()

--- a/packages/chat-ui/src/e2e/in-memory-fs-backend.ts
+++ b/packages/chat-ui/src/e2e/in-memory-fs-backend.ts
@@ -1,0 +1,35 @@
+import type { FsBackend } from '@buildaharness/runtime'
+
+/**
+ * A tiny in-memory {@link FsBackend} for E2E / jsdom tests — the `makeFsBackend` an
+ * {@link import('../assistant-test-hooks').AssistantTestHooks} installs so a plain-browser
+ * assistant turn has `fileTools` configured and actually runs the tool loop. No real files.
+ *
+ * `seed` pre-populates it (keys are absolute paths under the `/workspace` root
+ * `buildAssistant()` passes). Built for plans/chat_ui_browser_e2e_plan.html phase B1.
+ */
+export function createInMemoryFsBackend(seed: Record<string, string> = {}): FsBackend {
+  const files = new Map<string, string>(Object.entries(seed))
+  return {
+    async readTextFile(path) {
+      return files.get(path)
+    },
+    async writeTextFile(path, contents) {
+      files.set(path, contents)
+    },
+    async removeFile(path) {
+      files.delete(path)
+    },
+    async mkdir() {
+      // No real directories to create.
+    },
+    async readDir(dir) {
+      const prefix = dir.endsWith('/') ? dir : `${dir}/`
+      const names: string[] = []
+      for (const key of files.keys()) {
+        if (key.startsWith(prefix) && !key.slice(prefix.length).includes('/')) names.push(key.slice(prefix.length))
+      }
+      return names
+    },
+  }
+}

--- a/packages/chat-ui/src/main.tsx
+++ b/packages/chat-ui/src/main.tsx
@@ -3,8 +3,20 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import { App } from './App'
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
-)
+async function bootstrap(): Promise<void> {
+  // E2E only: publish the scripted-client / in-memory-FS factories on window before <App/> mounts
+  // and builds its assistant, so a Playwright `addInitScript` can wire the B1 test hooks. The
+  // `=== '1'` guard is constant-folded to `false` in production builds, so this dynamic import is
+  // tree-shaken out entirely — the E2E runtime never ships to real users. See e2e/e2e-runtime.ts.
+  if (import.meta.env.VITE_E2E === '1') {
+    await import('./e2e/e2e-runtime')
+  }
+
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  )
+}
+
+void bootstrap()

--- a/packages/chat-ui/src/types.ts
+++ b/packages/chat-ui/src/types.ts
@@ -16,6 +16,8 @@ export type ChatEntry =
       planStatus?: AssistantTurnResult['planStatus']
       /** Epistemic-honesty signal — see AssistantTurnResult.answerClaim's doc comment. Absent on the triviality fast path, same convention as trace/sources. */
       answerClaim?: AnswerClaim
+      /** Which proposer drove this turn — see AssistantTurnResult.proposerKind. A dev/E2E-only test affordance (plans/chat_ui_browser_e2e_plan.html phase B1), rendered as a hidden data-testid element. */
+      proposerKind?: AssistantTurnResult['proposerKind']
     }
   | {
       id: string

--- a/packages/chat-ui/vitest.config.ts
+++ b/packages/chat-ui/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { configDefaults, defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
@@ -7,5 +7,9 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test-setup.ts'],
+    // `e2e/` holds Playwright specs (`*.spec.ts`), which Vitest's default glob would otherwise
+    // pick up and fail on (`@playwright/test` is not a Vitest runner). They run via
+    // `npm run test:e2e` / phase B4's CI job. See plans/chat_ui_browser_e2e_plan.html B2.
+    exclude: [...configDefaults.exclude, 'e2e/**'],
   },
 })

--- a/packages/personal-assistant/src/assistant-types.ts
+++ b/packages/personal-assistant/src/assistant-types.ts
@@ -26,10 +26,29 @@ export interface AssistantTrace {
   batchBudget?: BatchBudgetTrace
 }
 
+/**
+ * Which code path actually produced this turn's reply — a test/telemetry affordance for
+ * plans/chat_ui_browser_e2e_plan.html phase B1 (the browser-e2e lane that unblocks the
+ * ASSISTANT_ONE_LOOP default-flip, R5 of the D2 one-loop rewire). The reply text itself is
+ * identical across all three by design (INV-19); this field is how a test asserts "the flag
+ * changed which path ran" without diffing internal traces.
+ *
+ * - 'posthoc'       — flag OFF (or a trivial / no-tool turn): AgentLoop.runToolLoop finished a
+ *                     draftReply before HarnessBridge constructed HarnessRuntime; the harness run
+ *                     is post-hoc bookkeeping over an already-produced reply.
+ * - 'flat-oneloop'  — flag ON, non-batch: the flat tool loop ran inside the harness's own
+ *                     driveMainLoop via AgentLoop.createOneLoopProposer.
+ * - 'batch-oneloop' — flag ON, batch-research: AgentLoop.createBatchOneLoopProposer drove the
+ *                     probe→calibrate→confirm→resolve→synthesize sequence under driveMainLoop.
+ */
+export type ProposerKind = 'posthoc' | 'flat-oneloop' | 'batch-oneloop'
+
 export interface AssistantTurnResult {
   status: 'ok' | 'needs_approval' | 'escalated'
   reply: string | null
   reason?: string
+  /** See ProposerKind. Always set (defaults to 'posthoc'), on every status. */
+  proposerKind?: ProposerKind
   riskLevel?: TurnIntentClassification['riskLevel']
   controlState?: { riskState: RiskState; escalationReason: string | null }
   stepsUsed?: number

--- a/packages/personal-assistant/src/assistant.test.ts
+++ b/packages/personal-assistant/src/assistant.test.ts
@@ -2236,14 +2236,16 @@ describe('PersonalAssistant onTrace', () => {
 
     await assistant.turn('What timezone is Tokyo in?', { sessionId: 'trace-trivial' })
 
-    // execution_mode_classified (Phase 4) is unconditionally traced every turn.
+    // execution_mode_classified (Phase 4) is unconditionally traced every turn; proposer_selected
+    // (chat_ui_browser_e2e_plan.html B1) is emitted once per non-bypass turn, right after risk.
     expect(events.map(e => e.kind)).toEqual([
-      'turn_start', 'risk_classified', 'triviality_classified', 'execution_mode_classified', 'turn_end',
+      'turn_start', 'risk_classified', 'proposer_selected', 'triviality_classified', 'execution_mode_classified', 'turn_end',
     ])
     expect(events[0]).toMatchObject({ kind: 'turn_start', sessionId: 'trace-trivial' })
-    expect(events[2]).toMatchObject({ kind: 'triviality_classified', isTrivial: true })
-    expect(events[3]).toMatchObject({ kind: 'execution_mode_classified', mode: 'FAST' })
-    expect(events[4]).toMatchObject({ kind: 'turn_end', status: 'ok' })
+    expect(events[2]).toMatchObject({ kind: 'proposer_selected', proposerKind: 'posthoc' })
+    expect(events[3]).toMatchObject({ kind: 'triviality_classified', isTrivial: true })
+    expect(events[4]).toMatchObject({ kind: 'execution_mode_classified', mode: 'FAST' })
+    expect(events[5]).toMatchObject({ kind: 'turn_end', status: 'ok' })
   })
 
   it('emits at least one harness_node event for a non-trivial turn that runs the full harness', async () => {

--- a/packages/personal-assistant/src/assistant.ts
+++ b/packages/personal-assistant/src/assistant.ts
@@ -35,7 +35,7 @@ import { DEFAULT_ONE_LOOP_MODE, type OneLoopMode } from './one-loop-flag.js'
 import { ResponseService } from './response-service.js'
 import type { AssistantSource } from './assistant-source.js'
 import type { DebugLogEntry } from './debug-log.js'
-import type { AssistantTrace, AssistantTurnResult, AssistantProgress } from './assistant-types.js'
+import type { AssistantTrace, AssistantTurnResult, AssistantProgress, ProposerKind } from './assistant-types.js'
 
 // Re-exported for full backward compatibility — every one of these used to be defined directly
 // in this file; they now live in the module that owns their logic (see each module's own doc
@@ -47,7 +47,7 @@ export type { BatchBudgetState } from './agent-loop.js'
 export { trimmedAverage, nextItemBudget } from './agent-loop.js'
 export type { AssistantSource } from './assistant-source.js'
 export type { DebugLogEntry } from './debug-log.js'
-export type { AssistantTrace, AssistantTurnResult, AssistantProgress } from './assistant-types.js'
+export type { AssistantTrace, AssistantTurnResult, AssistantProgress, ProposerKind } from './assistant-types.js'
 
 const isBrowser = (): boolean => typeof indexedDB !== 'undefined'
 
@@ -202,6 +202,14 @@ export class PersonalAssistant {
   private readonly toolLoopWillRun: boolean
   /** R3 of plans/harness_d2_one_loop_rewire_plan.html — mirrors the same flag HarnessBridge was given at construction, kept here too so runTurn can decide whether to defer the tool loop into a harness-driven proposer instead of precomputing draftReply. See PersonalAssistantOptions.oneLoopMode's doc comment. */
   private readonly oneLoopMode: OneLoopMode
+  /**
+   * Scratch slot for which proposer drove the most recent runTurn — read by `turn()` to stamp
+   * AssistantTurnResult.proposerKind, and emitted as a 'proposer_selected' trace event from
+   * runTurn itself. A single mutable field is safe because `turn()` is awaited end to end (turns
+   * never overlap within one instance). See AssistantTurnResult.proposerKind and
+   * plans/chat_ui_browser_e2e_plan.html phase B1.
+   */
+  private lastProposerKind: ProposerKind = 'posthoc'
 
   private readonly memoryService: MemoryService
   private readonly session: AssistantSession
@@ -303,6 +311,9 @@ export class PersonalAssistant {
    */
   async turn(userMessage: string, options: TurnOptions = {}): Promise<AssistantTurnResult> {
     const sessionId = options.sessionId ?? 'default'
+    // Reset per turn — runTurn flips it to 'flat-oneloop'/'batch-oneloop' only on the flag-ON
+    // paths that actually defer the tool loop into a harness-driven proposer.
+    this.lastProposerKind = 'posthoc'
     this.onTrace?.({ kind: 'turn_start', sessionId, message: userMessage })
     this.onDebugLog?.({ kind: 'user_message', sessionId, content: userMessage })
 
@@ -317,12 +328,16 @@ export class PersonalAssistant {
       const check = await this.session.checkSpendCapForTurn(sessionId)
       if (!check.allowed) {
         this.onTrace?.({ kind: 'turn_end', sessionId, status: 'escalated' })
-        return { status: 'escalated', reply: null, reason: check.reason }
+        return { status: 'escalated', reply: null, reason: check.reason, proposerKind: 'posthoc' }
       }
     }
 
     try {
       const result = await this.runTurn(userMessage, options, sessionId)
+      // Every return path leaves proposerKind unset — stamp the one runTurn resolved (defaults
+      // to 'posthoc'). A path that already set it explicitly (the spend-cap early return above)
+      // never reaches here.
+      result.proposerKind = this.lastProposerKind
       if (result.status === 'ok') await this.session.recordSpend(sessionId, result.usage)
       this.onTrace?.({ kind: 'turn_end', sessionId, status: result.status })
       this.onDebugLog?.({
@@ -510,6 +525,7 @@ export class PersonalAssistant {
       const useOneLoop = this.oneLoopMode === 'enabled' && !classification.isTrivial
 
       if (useOneLoop && batch) {
+        this.lastProposerKind = 'batch-oneloop'
         const built = this.agentLoop.createBatchOneLoopProposer(
           batch.items, sessionId, userMessage, systemPrompt, options.onToken, options.onToolStep, accumulateUsage,
         )
@@ -518,6 +534,7 @@ export class PersonalAssistant {
         oneLoopBatchBudget = built.getBatchBudget
         draftReply = ''
       } else if (useOneLoop) {
+        this.lastProposerKind = 'flat-oneloop'
         const built = this.agentLoop.createOneLoopProposer(
           sessionId, transcript, userMessage, systemPrompt, options.onToken, options.onToolStep, accumulateUsage, classification.riskLevel,
         )
@@ -564,6 +581,7 @@ export class PersonalAssistant {
     // entirely — no verification/reviewer pass/checkpoint for this turn. Deliberately
     // conservative: see turn-intent-classifier.ts's isTrivial contract for what disqualifies a
     // turn from this path.
+    this.onTrace?.({ kind: 'proposer_selected', proposerKind: this.lastProposerKind })
     this.onTrace?.({ kind: 'triviality_classified', isTrivial: classification.isTrivial })
     // Phase D3: recomputed via turn-policy.ts rather than read directly off
     // classification.requiresApproval — see turn-interpreter.ts's identical call for why.

--- a/packages/personal-assistant/src/index.ts
+++ b/packages/personal-assistant/src/index.ts
@@ -1,5 +1,5 @@
 export { PersonalAssistant } from './assistant.js'
-export type { AssistantTurnResult, PersonalAssistantOptions, AssistantProgress, AssistantTrace, AssistantSource, MemorySummary, TranscriptSearchHit, DebugLogEntry } from './assistant.js'
+export type { AssistantTurnResult, ProposerKind, PersonalAssistantOptions, AssistantProgress, AssistantTrace, AssistantSource, MemorySummary, TranscriptSearchHit, DebugLogEntry } from './assistant.js'
 export type { AnswerClaim, AnswerClaimSourceType, AnswerClaimVerificationStatus } from './answer-claim.js'
 export { classifyRisk } from './risk-classifier.js'
 export type { RiskClassification } from './risk-classifier.js'
@@ -77,6 +77,9 @@ export { resolveConfig, validateConfig, ConfigValidationError, DEFAULT_CONFIG, C
 export type { AssistantConfig, ConfigStore, ResolvedConfig } from './config.js'
 export { resolveOneLoopMode, normalizeOneLoopMode, DEFAULT_ONE_LOOP_MODE } from './one-loop-flag.js'
 export type { OneLoopMode } from './one-loop-flag.js'
+// Deterministic, network-free ILLMClient for tests and demos — see plans/chat_ui_browser_e2e_plan.html phase B1.
+export { createScriptedLLMClient } from './scripted-llm-client.js'
+export type { ScriptedLLMClientScript } from './scripted-llm-client.js'
 // Pure, browser-safe formatters — deliberately NOT cli-config.ts/cli-session.ts's env-var-specific
 // exports (formatHelp, formatStatus, CLI_COMMANDS_HELP), which are CLI-syntax-specific
 // (e.g. "/model [name]") and have no GUI equivalent. These are plain data-in/text-out

--- a/packages/personal-assistant/src/scripted-llm-client.test.ts
+++ b/packages/personal-assistant/src/scripted-llm-client.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import type { FsBackend } from '@buildaharness/runtime'
+import { PersonalAssistant } from './assistant.js'
+import { createScriptedLLMClient } from './scripted-llm-client.js'
+import type { TraceEvent } from './trace-events.js'
+
+/** In-memory FsBackend so `fileTools` is configured and the tool loop actually runs. */
+function makeFakeBackend(): FsBackend {
+  const files = new Map<string, string>([['/ws/note.txt', 'hello from a seeded file']])
+  return {
+    async readTextFile(path) {
+      return files.get(path)
+    },
+    async writeTextFile(path, contents) {
+      files.set(path, contents)
+    },
+    async removeFile(path) {
+      files.delete(path)
+    },
+    async mkdir() {},
+    async readDir(dir) {
+      const prefix = `${dir}/`
+      return [...files.keys()].filter((k) => k.startsWith(prefix) && !k.slice(prefix.length).includes('/')).map((k) => k.slice(prefix.length))
+    },
+  }
+}
+
+describe('createScriptedLLMClient', () => {
+  it('auto-answers classifyTurnIntent and plays back a scripted final answer', async () => {
+    const llm = createScriptedLLMClient({ responses: ['The answer is 84.'] })
+    const assistant = new PersonalAssistant({ llmClient: llm, fileTools: { backend: makeFakeBackend(), workspaceRoot: '/ws' } })
+
+    const result = await assistant.turn('What is 12 x 7?')
+
+    expect(result.status).toBe('ok')
+    expect(result.reply).toBe('The answer is 84.')
+  })
+
+  it('respects a classify() override for the triviality fast path', async () => {
+    const llm = createScriptedLLMClient({
+      streamChunks: ['Tokyo is UTC+9.'],
+      classify: () => ({ isTrivial: true }),
+    })
+    const assistant = new PersonalAssistant({ llmClient: llm })
+
+    const result = await assistant.turn('What timezone is Tokyo in?')
+
+    expect(result.status).toBe('ok')
+    expect(result.reply).toBe('Tokyo is UTC+9.')
+    expect(result.harnessSkipped).toBe(true)
+  })
+})
+
+describe('AssistantTurnResult.proposerKind', () => {
+  const script = () => ({
+    responses: [
+      { content: '', toolCalls: [{ id: 't1', name: 'read_file', input: { path: 'note.txt' } }] },
+      'The file says: hello from a seeded file',
+    ],
+  })
+
+  it('flag OFF → posthoc, and a proposer_selected trace event is emitted', async () => {
+    const events: TraceEvent[] = []
+    const assistant = new PersonalAssistant({
+      llmClient: createScriptedLLMClient(script()),
+      fileTools: { backend: makeFakeBackend(), workspaceRoot: '/ws' },
+      onTrace: (e) => events.push(e),
+    })
+
+    const result = await assistant.turn('Read note.txt and tell me what it says')
+
+    expect(result.status).toBe('ok')
+    expect(result.proposerKind).toBe('posthoc')
+    expect(events).toContainEqual({ kind: 'proposer_selected', proposerKind: 'posthoc' })
+  })
+
+  it('flag ON (non-batch) → flat-oneloop, with identical reply text', async () => {
+    const off = new PersonalAssistant({
+      llmClient: createScriptedLLMClient(script()),
+      fileTools: { backend: makeFakeBackend(), workspaceRoot: '/ws' },
+    })
+    const on = new PersonalAssistant({
+      llmClient: createScriptedLLMClient(script()),
+      fileTools: { backend: makeFakeBackend(), workspaceRoot: '/ws' },
+      oneLoopMode: 'enabled',
+    })
+
+    const offResult = await off.turn('Read note.txt and tell me what it says')
+    const onResult = await on.turn('Read note.txt and tell me what it says')
+
+    expect(offResult.proposerKind).toBe('posthoc')
+    expect(onResult.proposerKind).toBe('flat-oneloop')
+    expect(onResult.reply).toBe(offResult.reply)
+  })
+})

--- a/packages/personal-assistant/src/scripted-llm-client.ts
+++ b/packages/personal-assistant/src/scripted-llm-client.ts
@@ -1,0 +1,119 @@
+import type {
+  ChatMessage,
+  ChatOptions,
+  ILLMClient,
+  LLMStructuredResponse,
+  ToolDefinition,
+} from '@buildaharness/runtime'
+import { classifyRisk } from './risk-classifier.js'
+
+/**
+ * A deterministic, network-free {@link ILLMClient} for tests and demos — the one publicly
+ * supported way to drive a real `PersonalAssistant` turn end to end without a proxy, an API key,
+ * or a live model. Built for plans/chat_ui_browser_e2e_plan.html phase B1 (the browser-e2e lane
+ * that unblocks the `ASSISTANT_ONE_LOOP` default-flip), and reusable by chat-ui's `demo-seed.ts`.
+ *
+ * It mirrors the shape of the internal `ScriptedToolLLMClient` that `assistant.test.ts` has used
+ * for a long time: every turn spends exactly one mandatory `classifyTurnIntent` call up front,
+ * which this client recognises (by a distinctive phrase from that classifier's system prompt) and
+ * answers on its own from a lightweight, deterministic default — so `responses` only has to
+ * script the *tool loop / one-loop proposer's* own calls, not that bookkeeping call.
+ *
+ * `responses` entries are consumed in order, one per non-classifier `callChatStructured` call:
+ *   - a plain `string` → `{ content: string }` (a final answer, no tool calls)
+ *   - an `LLMStructuredResponse` → use as-is (set `toolCalls` to simulate the model calling a tool)
+ *
+ * `callChat`/`callChatSync` (the no-tools reply path, and post-approval synthesis) stream
+ * `streamChunks` (default: `['']`).
+ */
+export interface ScriptedLLMClientScript {
+  /** Ordered structured responses for the tool loop / one-loop proposer. A bare string is shorthand for a final answer with no tool calls. */
+  responses?: Array<string | LLMStructuredResponse>
+  /** Chunks streamed from `callChat`/`callChatSync`. Defaults to `['']`. */
+  streamChunks?: string[]
+  /**
+   * Per-user-message override of the auto-answered `classifyTurnIntent` JSON fields (e.g.
+   * `{ isTrivial: true }`, `{ riskLevel: 'HIGH' }`, `{ decomposedTasks: [...] }`). Return
+   * `undefined` to keep the derived default for that message.
+   */
+  classify?: (userMessage: string) => Record<string, unknown> | undefined
+}
+
+/** The phrase that opens `turn-intent-classifier.ts`'s system prompt — stable, and how every scripted client tells that mandatory call apart from a real tool-loop call. */
+const TURN_INTENT_MARKER = 'seven independent judgments'
+
+function isTurnIntentRequest(messages: ChatMessage[]): boolean {
+  return messages.some((m) => m.role === 'system' && m.content.includes(TURN_INTENT_MARKER))
+}
+
+/**
+ * The deterministic stand-in for what a real model would return for `classifyTurnIntent` —
+ * risk comes from the same lexical `classifyRisk` the real fallback path uses; everything else
+ * is inert (not trivial, not a reminder, no decomposition, no plan template) unless `override`
+ * says otherwise. `isTrivial` defaults to `false` so a scripted turn actually exercises the
+ * harness loop (the interesting case for one-loop parity tests); pass `{ isTrivial: true }` via
+ * `classify` for the triviality fast path.
+ */
+function deriveTurnIntentJSON(messages: ChatMessage[], override?: Record<string, unknown>): string {
+  const userContent = messages.find((m) => m.role === 'user')?.content ?? ''
+  const risk = classifyRisk(userContent)
+  const isReminderRequest = risk.reason.includes('reminder')
+  const base = {
+    riskLevel: risk.riskLevel,
+    riskReason: risk.reason,
+    isTrivial: false,
+    decomposedTasks: [],
+    isReminderRequest,
+    isBulkReminderRequest: isReminderRequest && risk.requiresApproval,
+    isAbandonRequest: false,
+    matchedPlanTemplate: null,
+    statesDurableFact: null,
+  }
+  return JSON.stringify({ ...base, ...override })
+}
+
+class ScriptedLLMClient implements ILLMClient {
+  /** Non-classifier `callChatStructured` calls made so far — the index into `responses`. */
+  toolCalls = 0
+  private responseIndex = 0
+
+  constructor(private readonly script: ScriptedLLMClientScript) {}
+
+  private get streamChunks(): string[] {
+    return this.script.streamChunks && this.script.streamChunks.length > 0 ? this.script.streamChunks : ['']
+  }
+
+  async *callChat(_messages: ChatMessage[], _options?: ChatOptions): AsyncIterable<string> {
+    for (const chunk of this.streamChunks) yield chunk
+  }
+
+  async callChatSync(messages: ChatMessage[], options?: ChatOptions): Promise<string> {
+    const chunks: string[] = []
+    for await (const chunk of this.callChat(messages, options)) chunks.push(chunk)
+    return chunks.join('')
+  }
+
+  async callChatStructured(messages: ChatMessage[], _tools?: ToolDefinition[], _options?: ChatOptions): Promise<LLMStructuredResponse> {
+    if (isTurnIntentRequest(messages)) {
+      const userContent = messages.find((m) => m.role === 'user')?.content ?? ''
+      return { content: deriveTurnIntentJSON(messages, this.script.classify?.(userContent)) }
+    }
+    this.toolCalls++
+    const responses = this.script.responses ?? []
+    if (this.responseIndex >= responses.length) {
+      throw new Error(
+        `createScriptedLLMClient: no scripted response for tool-loop call #${this.responseIndex + 1} (scripted ${responses.length})`,
+      )
+    }
+    const next = responses[this.responseIndex++]
+    return typeof next === 'string' ? { content: next } : next
+  }
+}
+
+/**
+ * Builds a scripted {@link ILLMClient}. See {@link ScriptedLLMClientScript}. The returned value
+ * is a plain `ILLMClient` — pass it straight to `PersonalAssistant.create({ llmClient })`.
+ */
+export function createScriptedLLMClient(script: ScriptedLLMClientScript = {}): ILLMClient {
+  return new ScriptedLLMClient(script)
+}

--- a/packages/personal-assistant/src/trace-events.ts
+++ b/packages/personal-assistant/src/trace-events.ts
@@ -1,6 +1,7 @@
 import type { RiskLevel } from './turn-intent-classifier.js'
 import type { ExecutionMode } from './execution-mode.js'
 import type { ToolPolicyDecision } from './tool-policy.js'
+import type { ProposerKind } from './assistant-types.js'
 
 /**
  * Structured turn telemetry — deliberately name/status-only, never full message
@@ -45,3 +46,10 @@ export type TraceEvent =
    * tool-policy.ts).
    */
   | { kind: 'tool_policy_decision'; tool: string; decision: ToolPolicyDecision; reason: string }
+  /**
+   * Which proposer drove this turn — 'posthoc' (flag OFF, or a trivial / no-tool turn),
+   * 'flat-oneloop', or 'batch-oneloop' (both flag ON). Emitted once per turn from runTurn, right
+   * after `useOneLoop` is resolved. See AssistantTurnResult.proposerKind and
+   * plans/chat_ui_browser_e2e_plan.html phase B1 for why this exists.
+   */
+  | { kind: 'proposer_selected'; proposerKind: ProposerKind }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,10 @@ export default defineConfig({
       '**/.{idea,git,cache,output,temp}/**',
       '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*',
       'templates/**',
+      // packages/chat-ui/e2e/ holds Playwright specs (`*.spec.ts`) — `@playwright/test` is not a
+      // Vitest runner, so the blanket root run must skip them just as chat-ui's own vitest.config.ts
+      // does. They run via `npm run test:e2e` / phase B4's CI job. See plans/chat_ui_browser_e2e_plan.html B2.
+      'packages/*/e2e/**',
     ],
   },
 })


### PR DESCRIPTION
Real-browser end-to-end test lane for `packages/chat-ui` (shared by the plain-browser tab and the Tauri desktop app), closing the "a human with a real browser" verification gap that the D2 One-Loop Rewire `ASSISTANT_ONE_LOOP` default-flip (R5, step 2) was blocked on.

Driven by clam's `plan_driver.py` against `plans/chat_ui_browser_e2e_plan.html` (private overlay), phases B1–B5. B6 (Tauri desktop via `tauri-driver`) stays blocked on a Rust-capable CI runner.

## What's here

| Phase | Commit | Content |
|---|---|---|
| B1 | `97d7945` + `301623b` | Test-only `ILLMClient` / `FsBackend` injection seam (`assistant-test-hooks.ts`, null in any prod build), exported `createScriptedLLMClient`, `proposerKind` telemetry (`'posthoc'` / `'flat-oneloop'` / `'batch-oneloop'`) on `AssistantTurnResult` + a `proposer_selected` trace event, hidden `data-testid="proposer-kind"` (dev/E2E only) |
| B2 | `9666566` | Playwright harness — `playwright.config.ts` (Chromium, headless, `vite preview` webServer), `e2e/fixtures.ts` page objects, smoke specs, `VITE_E2E` runtime seam |
| B3 | `ab8036c` | Flag OFF vs ON parity matrix — 6 scenarios (benign, read-only tool, staged write approve/deny, failing tool, escalation) asserting identical reply text with `proposerKind` flipped |
| B4 | `dd0dec1` | `.github/workflows/browser-e2e.yml` — Chromium cached, PR + nightly triggers |
| — | `301623b` | The B1 seam wired into pre-existing files (the per-phase commits only captured new files) |
| — | `e9313a3` | Regenerated stats for the new test files |

## Verification

- **Gate green:** `lint`, `typecheck` ×3, `npm test` (**2042 vitest**), `check-schema-sync`
- **Real browser suite green:** ran `playwright test` in headless Chromium (installed locally) — **8/8 pass** (6-scenario parity matrix + 2 smoke). This is the run R5 was blocked on.

## Notes

- Flag-OFF / no-hook behaviour is byte-identical to `main` — the seam returns `null` in any production build.
- One pre-existing exact trace-sequence assertion in `assistant.test.ts` was updated for the additive `proposer_selected` event (trace ordering, not reply semantics).
- `.gitignore` / `.githooks/` are present but untracked in the repo and left out of this PR — separate pre-existing concern (issue #42).

🤖 Generated with [Claude Code](https://claude.com/claude-code)