### PR TITLE
ci(eval): build harness + runtime before the personal-assistant typecheck

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -195,6 +195,14 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+      # packages/personal-assistant imports @buildaharness/harness and
+      # @buildaharness/runtime by their built dist/ — tsc and the tsx benchmark
+      # run both resolve them from there, so build them first. Same prerequisite
+      # as ci.yml's "@buildaharness/personal-assistant" job.
+      - name: Build workspace deps (harness, runtime)
+        run: |
+          npm run build:harness
+          npm run build:runtime
       - name: Push — LLM-free sanity (typecheck + baseline.json parses)
         if: github.event_name == 'push'
         run: |


### PR DESCRIPTION
## The failure

The **Offline eval harness** workflow has been red on every push to `main` since #30 — its "Harness comparative benchmark" job fails in ~15s at:

```
npm run typecheck:personal-assistant
##[error]src/assistant.ts(1,127): error TS2307: Cannot find module '@buildaharness/harness'
##[error]eval/arms.ts(17,33): error TS2307: Cannot find module '@buildaharness/runtime'
… (hundreds more)
```

`#30` added a push-path sanity step that runs `typecheck:personal-assistant` straight after `npm ci`. But `packages/personal-assistant` resolves `@buildaharness/harness` and `@buildaharness/runtime` from their built `dist/`, which `npm ci` doesn't produce — so `tsc` can't find them.

## The fix

Add the same `build:harness` + `build:runtime` steps that `ci.yml`'s own `@buildaharness/personal-assistant` job already runs (it has a comment: *"dist/ must exist before typecheck/test"*), before both the push typecheck and the nightly `tsx` benchmark run (which needs them too).

Pre-existing — not from #31/#32. One job, one added step.

## Verification

`npm ci && npm run build:harness && npm run build:runtime && npm run typecheck:personal-assistant` → exit 0 locally; the `baseline.json` parse check passes. `eval.yml` only runs on push-to-`main`, so this can't be exercised by a PR check — it validates on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)