### PR TITLE
S5 trajectory supervisor — decider wired into the PA path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Version](https://img.shields.io/badge/version-v0.8.0-brightgreen.svg)](https://github.com/3IVIS/buildaharness/releases)
 [![Status](https://img.shields.io/badge/status-public%20alpha-orange.svg)](https://github.com/3IVIS/buildaharness)
-[![Tests](https://img.shields.io/badge/tests-3%2C448%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/tests-3%2C453%20passing-brightgreen.svg)](#)
 [![GitHub Stars](https://img.shields.io/github/stars/3IVIS/buildaharness?style=social)](https://github.com/3IVIS/buildaharness/stargazers)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Node.js](https://img.shields.io/badge/Node.js-18+-339933.svg?logo=node.js&logoColor=white)](https://nodejs.org/)

--- a/README_CN.md
+++ b/README_CN.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/许可证-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Version](https://img.shields.io/badge/版本-v0.8.0-brightgreen.svg)](https://github.com/3IVIS/buildaharness/releases)
 [![Status](https://img.shields.io/badge/状态-公开测试版-orange.svg)](https://github.com/3IVIS/buildaharness)
-[![Tests](https://img.shields.io/badge/测试-3%2C448%20通过-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/测试-3%2C453%20通过-brightgreen.svg)](#)
 [![GitHub Stars](https://img.shields.io/github/stars/3IVIS/buildaharness?style=social)](https://github.com/3IVIS/buildaharness/stargazers)
 [![PRs Welcome](https://img.shields.io/badge/欢迎-PR贡献-brightgreen.svg)](CONTRIBUTING.md)
 [![Node.js](https://img.shields.io/badge/Node.js-18+-339933.svg?logo=node.js&logoColor=white)](https://nodejs.org/)

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -8,9 +8,9 @@ not transcluded, since GitHub-rendered markdown has no include mechanism.
 
 | Metric | Count | Source |
 |---|---|---|
-| Frontend tests (vitest) | 2131 across 139 files | `npm test` (root — aggregates src/ and every packages/* workspace) |
+| Frontend tests (vitest) | 2136 across 140 files | `npm test` (root — aggregates src/ and every packages/* workspace) |
 | Adapter tests (pytest) | 1317 | `pytest adapter/tests/ -v` |
 | MAF adapter tests | 42 | `pytest adapter/tests/test_maf_adapter.py -v` |
-| Project-wide tests | 3,448 | pytest + vitest combined |
+| Project-wide tests | 3,453 | pytest + vitest combined |
 | Node types | 27 (14 execution + 13 harness) | `Node`/`HarnessNode` discriminated unions in `spec/schema.ts` |
 | Docker Compose services | 12 | `docker-compose.yml` top-level `services:` keys, excluding one-shot `restart: "no"` init jobs |

--- a/packages/personal-assistant/eval/README.md
+++ b/packages/personal-assistant/eval/README.md
@@ -141,15 +141,16 @@ Run the slice:
 
 ```
 npx tsx scripts/run-harness-benchmark.ts --slice=supervisor_pivot,supervisor_lookup,supervisor_clarification,supervisor_adversarial_digest
-npx tsx scripts/run-harness-benchmark.ts --slice=supervisor_clarification --arms=baseline,supervisorOn --gate=eval/reports/<before>.json --gate-arm=supervisorOn
+npx tsx scripts/run-harness-benchmark.ts --slice=supervisor_pivot,supervisor_lookup,supervisor_clarification,supervisor_adversarial_digest --arms=flagOn,supervisorOn --gate=eval/reports/<before>.json --gate-arm=supervisorOn
 ```
 
-**`supervisorOn` arm** — `PersonalAssistant` with `HARNESS_TRAJECTORY_SUPERVISOR=enabled`. It is in
-`ALL_ARMS` but **not `IMPLEMENTED_ARMS`**, so the default run does not include it. Reason: the S5
-follow-up (wire `supervisorDecider` into `harness-bridge.ts`) has not landed, so the flag currently
-has **no observable effect** from the PA path — `supervisorOn` is byte-for-byte `flagOn` until then.
-Once the decider is wired, move `supervisorOnArm` into `IMPLEMENTED_ARMS` and the nightly job flips
-to `--arms=baseline,supervisorOn --gate-arm=supervisorOn`.
+**`supervisorOn` arm** — `PersonalAssistant` with `HARNESS_TRAJECTORY_SUPERVISOR=enabled`. As of S5
+`harness-bridge.ts` reads `supervisorEnabled()` and, when set, passes a real `supervisorDecider`
+(`src/supervisor-decider.ts` — one LLM call on the stall digest) + `askUser` host into the harness
+run, so this arm genuinely diverges from `flagOn`: the only difference is the trajectory supervisor
+being consulted on the `cannotMakeProgress()` stall edge. It is now in `IMPLEMENTED_ARMS`. The Rule 6
+comparison for the default-on flip is **`flagOn` vs `supervisorOn`** (isolates the supervisor; both
+run one-loop), not `baseline` vs `supervisorOn`.
 
 **Rule 6 for the flag default-on** (`HARNESS_TRAJECTORY_SUPERVISOR`, currently OFF): the
 `supervisorOn` arm must beat `baseline` on the recovery + adversarial + supervisor slices with **no

--- a/packages/personal-assistant/eval/arms.ts
+++ b/packages/personal-assistant/eval/arms.ts
@@ -45,8 +45,9 @@ async function runAssistant(
 
   // The trajectory supervisor (plans/harness_trajectory_supervisor_plan.html) is gated on this
   // env flag in both twins. Arms run sequentially (runner.ts), so a set/restore around the turn
-  // is safe. NOTE: until the S5 follow-up wires `supervisorDecider` into harness-bridge.ts, this
-  // flag has no observable effect from the PA path — `supervisorOn` is currently ≡ `flagOn`.
+  // is safe. harness-bridge.ts reads supervisorEnabled() (→ this env var) to decide whether to
+  // pass a supervisorDecider / askUser host into the harness run, so `supervisorOn` genuinely
+  // diverges from `flagOn` as of S5 — the differential is the stall-edge supervisor call.
   const priorFlag = process.env.HARNESS_TRAJECTORY_SUPERVISOR
   if (supervisor) process.env.HARNESS_TRAJECTORY_SUPERVISOR = 'enabled'
   try {
@@ -133,9 +134,10 @@ export const supervisorOnArm: Arm = {
   name: 'supervisorOn',
   label:
     'PersonalAssistant with HARNESS_TRAJECTORY_SUPERVISOR=enabled — the S7 supervisor-vs-no-supervisor differential arm',
-  // Not in IMPLEMENTED_ARMS yet: the S5 follow-up (wire `supervisorDecider` into harness-bridge.ts)
-  // must land before this arm diverges from `flagOn`. Select it explicitly with
-  // `--arms=baseline,supervisorOn` once that wiring exists. See plan S5 "Still TODO" + S7.
+  // Same one-loop config as `flagOn`; the only difference is the trajectory supervisor being
+  // consulted on the cannotMakeProgress() stall edge. The Rule 6 comparison for the flag
+  // default-on flip is `flagOn` vs `supervisorOn` (isolates the supervisor), run over the S7
+  // `--slice=` corpus multi-seed — see eval/README.md.
   run: (task, makeLlm) => runAssistant(task, makeLlm, 'enabled', true),
 }
 
@@ -147,5 +149,5 @@ export const langgraphArm: Arm = {
   },
 }
 
-export const IMPLEMENTED_ARMS: Arm[] = [baselineArm, flagOnArm, bareArm]
+export const IMPLEMENTED_ARMS: Arm[] = [baselineArm, flagOnArm, bareArm, supervisorOnArm]
 export const ALL_ARMS: Arm[] = [baselineArm, flagOnArm, bareArm, supervisorOnArm, langgraphArm]

--- a/packages/personal-assistant/src/harness-bridge.ts
+++ b/packages/personal-assistant/src/harness-bridge.ts
@@ -16,7 +16,12 @@ import {
   type ToolExecutorContext,
   type InvestigationRequestData,
   type InvestigationFinding,
+  type TrajectoryDigestData,
+  type SupervisorDirective,
+  type UserQuestionData,
+  supervisorEnabled,
 } from '@buildaharness/harness'
+import { decideSupervisorDirective } from './supervisor-decider.js'
 import type { ILLMClient, MemoryAdapter, TokenUsage } from '@buildaharness/runtime'
 import { DEFAULT_ONE_LOOP_MODE, type OneLoopMode } from './one-loop-flag.js'
 import { extractFactsFromTurn, tierForFact, isKnowledgeTier, type UserFact } from './fact-extraction.js'
@@ -206,6 +211,25 @@ export class HarnessBridge {
         // also wired and returns a GATHER_EVIDENCE directive at a stall edge; absent → the
         // harness degrades GATHER_EVIDENCE to CONTINUE.
         runInvestigation,
+        // Trajectory Supervisor decider (S5) — the single stall-edge LLM call. Flag-gated on
+        // HARNESS_TRAJECTORY_SUPERVISOR (default OFF); when off, the harness never consults it
+        // and the whole supervisor path stays inert (INV-22). The harness itself only calls this
+        // inside its own cannotMakeProgress() branch. Twin of planner_api.py's _run_planner gate.
+        supervisorDecider: supervisorEnabled()
+          ? (digest: TrajectoryDigestData) => decideSupervisorDirective(digest, this.llmClient, this.model(), onUsage)
+          : undefined,
+        onSupervisorDirective: (directive: SupervisorDirective) => {
+          this.onTrace?.({ kind: 'layer_activity', layer: 'supervisor', fired: directive.action !== 'CONTINUE', reason: `${directive.action}: ${directive.rationale}`.slice(0, 200) })
+        },
+        // Trajectory Supervisor ASK_USER host (S3) — its presence is what lets an ASK_USER
+        // directive surface as a structured supervisor_question escalation instead of degrading
+        // to a plain one. The escalation itself is carried out of run() as an EscalationHalt and
+        // surfaced to the user by the sequencer; this hook is observability only.
+        askUser: supervisorEnabled()
+          ? (q: UserQuestionData) => {
+              this.onTrace?.({ kind: 'layer_activity', layer: 'supervisor', fired: true, reason: `ASK_USER: ${q.question}`.slice(0, 200) })
+            }
+          : undefined,
         // Layered on top of the harness's own always-on lexical/negation-pair check — one call
         // per belief-set growth (never per-pair, never a full re-scan), and skipped entirely
         // when every newly-added belief looks like a structured/technical claim the lexical

--- a/packages/personal-assistant/src/supervisor-decider.test.ts
+++ b/packages/personal-assistant/src/supervisor-decider.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import type { ChatMessage, ILLMClient, LLMStructuredResponse } from '@buildaharness/runtime'
+import type { TrajectoryDigestData } from '@buildaharness/harness'
+import { decideSupervisorDirective } from './supervisor-decider.js'
+
+const DIGEST: TrajectoryDigestData = {
+  goal: ['ship the widget'],
+  steps_taken: 12,
+  stall_reason: 'strategy_loop',
+  stall_history: ['0', '0', '0'],
+  strategies_tried: [{ strategy: 'DIRECT_EDIT', outcome: 'switched' }],
+  failure_classes: [],
+  reopened_tasks: [],
+  open_contradictions: [],
+  blocking_unknowns: ['which config file is authoritative'],
+  budget_remaining: {},
+}
+
+class FixedLLMClient implements ILLMClient {
+  calls = 0
+  received: ChatMessage[][] = []
+  constructor(private readonly content: string) {}
+  async *callChat(): AsyncIterable<string> {
+    yield ''
+  }
+  async callChatSync(): Promise<string> {
+    return ''
+  }
+  async callChatStructured(messages: ChatMessage[]): Promise<LLMStructuredResponse> {
+    this.calls++
+    this.received.push(messages)
+    return { content: this.content }
+  }
+}
+
+class ThrowingLLMClient implements ILLMClient {
+  async *callChat(): AsyncIterable<string> {
+    yield ''
+  }
+  async callChatSync(): Promise<string> {
+    return ''
+  }
+  async callChatStructured(): Promise<LLMStructuredResponse> {
+    throw new Error('backend unreachable')
+  }
+}
+
+describe('decideSupervisorDirective', () => {
+  it('passes the digest through and returns the parsed directive object', async () => {
+    const llm = new FixedLLMClient('{"action":"REDIRECT_STRATEGY","rationale":"tried direct edits twice","strategy_hint":"TRACE_EXEC","plan_note":null,"investigation":null,"question":null}')
+    const out = await decideSupervisorDirective(DIGEST, llm)
+    expect(llm.calls).toBe(1)
+    expect(JSON.parse(llm.received[0][1].content as string)).toEqual(DIGEST)
+    expect(out).toMatchObject({ action: 'REDIRECT_STRATEGY', strategy_hint: 'TRACE_EXEC' })
+  })
+
+  it('returns an ASK_USER directive with its structured question intact', async () => {
+    const llm = new FixedLLMClient('{"action":"ASK_USER","rationale":"two configs, cannot tell which","question":{"question":"which config is authoritative?","options":["a.yaml","b.yaml"]}}')
+    const out = await decideSupervisorDirective(DIGEST, llm)
+    expect(out?.action).toBe('ASK_USER')
+    expect((out as { question?: { question: string } }).question?.question).toBe('which config is authoritative?')
+  })
+
+  it('fails safe to null (→ CONTINUE) on an LLM error', async () => {
+    expect(await decideSupervisorDirective(DIGEST, new ThrowingLLMClient())).toBeNull()
+  })
+
+  it('fails safe to null on an unparseable body', async () => {
+    expect(await decideSupervisorDirective(DIGEST, new FixedLLMClient('not json at all'))).toBeNull()
+  })
+
+  it('fails safe to null when the body parses to a non-object', async () => {
+    expect(await decideSupervisorDirective(DIGEST, new FixedLLMClient('"just a string"'))).toBeNull()
+  })
+})

--- a/packages/personal-assistant/src/supervisor-decider.ts
+++ b/packages/personal-assistant/src/supervisor-decider.ts
@@ -1,0 +1,92 @@
+import type { ILLMClient, TokenUsage } from '@buildaharness/runtime'
+import type { SupervisorDirectiveData, TrajectoryDigestData } from '@buildaharness/harness'
+
+/**
+ * Trajectory Supervisor decider (S5 host wiring of
+ * plans/harness_trajectory_supervisor_plan.html) — the single LLM call the harness makes
+ * ONLY on the `cannotMakeProgress()` stall edge, wired here as the personal-assistant's
+ * `HarnessRunOptions.supervisorDecider`. TS twin of adapter/harness/supervisor.py's
+ * `decide_supervisor_directive()`.
+ *
+ * Given the bounded stall digest, return one directive from the closed enum. The harness's
+ * own `resolveSupervisorDirective()` → `SupervisorDirective.fromJSON()` handles enum-safety,
+ * payload-shape coercion, and length caps, so this only has to produce a best-effort object.
+ *
+ * Fail-safe: any LLM error, timeout, or unparseable body resolves to CONTINUE (the
+ * deterministic recovery ladder) — never a more aggressive action. Same discipline as
+ * turn-intent-classifier.ts's failSafeClassification() and checkForContradictions().
+ */
+
+const SYSTEM_PROMPT =
+  'You are a trajectory supervisor for a long-running autonomous assistant. The run has ' +
+  'STALLED — it is not making progress. You are given a bounded JSON digest of the trajectory ' +
+  '(the goal, steps taken, why it stalled, strategies already tried, recurring failure classes, ' +
+  'reopened tasks, open contradictions, and blocking unknowns). Choose the SINGLE cheapest ' +
+  'intervention that could get it unstuck. You never make tactical decisions, only redirect. ' +
+  'Respond with JSON only:\n' +
+  '{"action": <one of "CONTINUE","REDIRECT_STRATEGY","REFRAME_PLAN","GATHER_EVIDENCE","ASK_USER",' +
+  '"ABORT">, "rationale": string, "strategy_hint": string|null, "plan_note": string|null, ' +
+  '"investigation": {"question": string, "suggested_tools": string[]}|null, ' +
+  '"question": {"question": string, "options": string[]}|null}\n' +
+  '- CONTINUE: let the deterministic recovery ladder proceed. Prefer this unless a targeted ' +
+  'intervention is clearly better.\n' +
+  '- REDIRECT_STRATEGY: switch approach now; put the concrete approach in "strategy_hint" (one of ' +
+  'DIRECT_EDIT, TRACE_EXEC, BROADER_SEARCH, REIMPLEMENT, MINIMAL_FIX).\n' +
+  '- REFRAME_PLAN: the whole task decomposition is wrong; describe the better framing in "plan_note".\n' +
+  '- GATHER_EVIDENCE: a specific missing fact is blocking progress and a bounded read-only lookup ' +
+  '(read a file, search) would resolve it; put the lookup in "investigation".\n' +
+  '- ASK_USER: the task is genuinely ambiguous or needs a decision only the user can make; put the ' +
+  'question (and any concrete choices) in "question". Use this sparingly — only when guessing would ' +
+  'be wrong.\n' +
+  '- ABORT: redirection is exhausted and the run is unrecoverable without new input.\n' +
+  'Always include "rationale". Use null for fields that do not apply to your action.'
+
+const SCHEMA = {
+  type: 'object',
+  properties: {
+    action: {
+      type: 'string',
+      enum: ['CONTINUE', 'REDIRECT_STRATEGY', 'REFRAME_PLAN', 'GATHER_EVIDENCE', 'ASK_USER', 'ABORT'],
+    },
+    rationale: { type: 'string' },
+    strategy_hint: { type: ['string', 'null'] },
+    plan_note: { type: ['string', 'null'] },
+    investigation: {
+      type: ['object', 'null'],
+      properties: {
+        question: { type: 'string' },
+        suggested_tools: { type: 'array', items: { type: 'string' } },
+      },
+    },
+    question: {
+      type: ['object', 'null'],
+      properties: {
+        question: { type: 'string' },
+        options: { type: 'array', items: { type: 'string' } },
+      },
+    },
+  },
+  required: ['action', 'rationale'],
+}
+
+export async function decideSupervisorDirective(
+  digest: TrajectoryDigestData,
+  llmClient: ILLMClient,
+  model?: string,
+  onUsage?: (usage: TokenUsage) => void,
+): Promise<Partial<SupervisorDirectiveData> | null> {
+  try {
+    const response = await llmClient.callChatStructured(
+      [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: JSON.stringify(digest) },
+      ],
+      undefined,
+      { model, onUsage, structuredOutput: { schema: SCHEMA } },
+    )
+    const parsed = JSON.parse(response.content) as Partial<SupervisorDirectiveData>
+    return parsed && typeof parsed === 'object' ? parsed : null
+  } catch {
+    return null // fail-safe → CONTINUE
+  }
+}


### PR DESCRIPTION
Follow-up to #36. Wires the trajectory supervisor's stall-edge LLM call into the personal-assistant path — the piece that was missing, so `HARNESS_TRAJECTORY_SUPERVISOR` previously had no observable effect there.

## Changes
- **`src/supervisor-decider.ts`** — `decideSupervisorDirective(digest, llmClient, model, onUsage)`: one structured LLM call on the bounded stall digest → a directive object. TS twin of `adapter/harness/supervisor.py`'s `decide_supervisor_directive()`. Fail-safe: any LLM error / unparseable body → `null` → `CONTINUE`.
- **`harness-bridge.ts`** — when `supervisorEnabled()` (`HARNESS_TRAJECTORY_SUPERVISOR`, default OFF), passes `supervisorDecider` + `onSupervisorDirective` + the `askUser` host into the harness run. OFF → none are passed, the whole supervisor path stays inert (INV-22). Same gate shape as `planner_api.py`'s `_run_planner`.
- **`eval/arms.ts`** — `supervisorOnArm` moved into `IMPLEMENTED_ARMS`; it now genuinely diverges from `flagOn` (same one-loop config, the only difference is the stall-edge supervisor call).
- Tests: `supervisor-decider.test.ts` (pass-through, ASK_USER payload, 3 fail-safe paths). Full PA suite green.

## Local benchmark run — flag stays OFF
One full-slice run (`flagOn` vs `supervisorOn`, 20 tasks, judge on, via `claude-cli`): `flagOn` 80% / `supervisorOn` 75% task-success; overconfident-and-wrong 11.8% → 6.3%. **Not a usable signal:**
- 4 of 9 failures are **grader false-negatives** — the model answered correctly and refused the injected instructions correctly, but transparently quoting the injected "ABORT"/"delete all" text trips a blunt `notContains`; a correct "0007 APPLIED, 0008 still PENDING" trips `notContains: ["still pending"]`.
- 2 tasks (`sup-clarify-cleanup-scope`, `sup-clarify-remove-old-one`) **errored on both arms**.
- **No row shows the supervisor was ever consulted** (`recovered: null` throughout) — the S7 slice tasks complete in 1–2 harness iterations and never reach `cannotMakeProgress()` in the single-turn PA path, so `supervisorOn` is behaviourally ≈ `flagOn` regardless of the wiring.

Per the plan's own Validation ("if the delta is not positive … the flag stays OFF"), `HARNESS_TRAJECTORY_SUPERVISOR` stays **OFF**. Real prerequisites for a flip decision: harden the ~9 S7 graders against a real model, fix the 2 erroring tasks, make the tasks actually induce the stall edge, then multi-seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)