### PR TITLE
runtime: point OpenRouter attribution headers at Aielia

### DIFF
--- a/packages/runtime/src/openai-compatible-client.ts
+++ b/packages/runtime/src/openai-compatible-client.ts
@@ -21,10 +21,15 @@ export interface OpenAICompatibleLLMClientOptions {
 export const OPENAI_BASE_URL = 'https://api.openai.com/v1'
 export const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1'
 export { OPENAI_DEFAULT_MODEL, OPENROUTER_DEFAULT_MODEL } from './model-defaults'
-/** OpenRouter's recommended (not required) leaderboard-attribution headers — see https://openrouter.ai/docs. */
+/**
+ * OpenRouter's recommended (not required) leaderboard-attribution headers — see
+ * https://openrouter.ai/docs. `HTTP-Referer` is rendered as the clickable link for
+ * the app on OpenRouter's rankings, so it points at the product page rather than the
+ * raw repo; `X-Title` is the display name shown there.
+ */
 export const OPENROUTER_EXTRA_HEADERS: Record<string, string> = {
-  'HTTP-Referer': 'https://github.com/3IVIS/buildaharness',
-  'X-Title': 'Build A Harness',
+  'HTTP-Referer': 'https://buildaharness.com/personal-assistant',
+  'X-Title': 'Aielia',
 }
 
 function parseToolCalls(toolCalls: unknown): ToolCallResult[] | undefined {


### PR DESCRIPTION
## What

`OPENROUTER_EXTRA_HEADERS` (`packages/runtime/src/openai-compatible-client.ts`) still carried the pre-rename identity:

- `X-Title: 'Build A Harness'` → `'Aielia'`
- `HTTP-Referer: 'https://github.com/3IVIS/buildaharness'` → `'https://buildaharness.com/personal-assistant'`

## Why

OpenRouter renders `HTTP-Referer` as the app's clickable link on its public model/app rankings and `X-Title` as the display name. This is free attribution/marketing visibility for every OpenRouter-backed request from the CLI and the chat-ui/desktop build (both already pass this constant). Pointing it at the product page and the current product name is the only change needed — the wiring has been in place.

## Risk

None beyond the header string values. The client already merges these into every OpenRouter request; the runtime test asserts against the constant rather than a literal, so it stays green. `typecheck` + full `packages/runtime` test suite (278) + `build` verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhxmWt7LbKb1qUbFZ3TZcc